### PR TITLE
Merge develop into master

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/config/GrantedAuthoritiesConverter.java
+++ b/app/src/main/java/tools/vitruv/methodologist/config/GrantedAuthoritiesConverter.java
@@ -26,19 +26,23 @@ public class GrantedAuthoritiesConverter implements Converter<Jwt, Collection<Gr
    */
   @Override
   public Collection<GrantedAuthority> convert(Jwt source) {
-    Map<String, Object> realmAccess = source.getClaimAsMap("realm_access");
-
-    if (realmAccess != null) {
-      Object rolesObj = realmAccess.get("roles");
-
-      if (rolesObj instanceof List<?> roles) {
-        return roles.stream()
-            .filter(String.class::isInstance)
-            .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
-            .collect(Collectors.toList());
-      }
+    if (source == null) {
+      return Collections.emptyList();
     }
 
-    return Collections.emptyList();
+    Map<String, Object> realmAccess = source.getClaimAsMap("realm_access");
+    if (realmAccess == null) {
+      return Collections.emptyList();
+    }
+
+    Object rolesObj = realmAccess.get("roles");
+    if (!(rolesObj instanceof List<?> roles)) {
+      return Collections.emptyList();
+    }
+
+    return roles.stream()
+        .filter(String.class::isInstance)
+        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+        .collect(Collectors.toList());
   }
 }

--- a/app/src/test/java/tools/vitruv/methodologist/vsum/service/impl/DockerEphemeralBuildServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/vsum/service/impl/DockerEphemeralBuildServiceTest.java
@@ -241,8 +241,12 @@ class DockerEphemeralBuildServiceTest {
       return code;
     }
 
+    /* For test */
     @Override
-    public void destroy() {}
+    public void destroy() {
+      // Intentionally left blank: FakeProcess is only used in tests and does not
+      // manage any real OS resources, so there is nothing to destroy.
+    }
 
     @Override
     public Process destroyForcibly() {


### PR DESCRIPTION
This pull request refactors validation logic and improves robustness in multiple areas of the codebase. The main changes include splitting up complex validation methods into smaller, focused helpers for Ecore model validation, improving null handling in JWT role conversion, and clarifying the implementation of a test utility.

### Validation logic refactoring (`SimpleValidators.java`):

* Broke down the `assertValidEcore` method into smaller helper methods: `validateResourceBasics`, `extractRootPackage`, `validatePackageBasics`, `validateClassifiers`, `validateClassifierName`, `validateClassFeatures`, `validateFeatureBasics`, and `validateFeatureType`. This improves readability, maintainability, and testability of Ecore validation. [[1]](diffhunk://#diff-b1b3b80417774435b876535f26d9ceb8c8effdf41c0849987516cf50b2795a93R28-R34) [[2]](diffhunk://#diff-b1b3b80417774435b876535f26d9ceb8c8effdf41c0849987516cf50b2795a93R44-R99)

### Robustness improvements (`GrantedAuthoritiesConverter.java`):

* Improved null handling in the `convert` method: now returns an empty list if the JWT source or its claims are missing, or if the roles claim is not a list. This makes role extraction safer and more predictable.

### Test utility clarification (`DockerEphemeralBuildServiceTest.java`):

* Added a comment and implementation to the `destroy` method in the `FakeProcess` test class, clarifying that it intentionally does nothing since no OS resources are managed.