### PR TITLE
feat: implement password reset functionality with email validation

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/user/controller/UserController.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/controller/UserController.java
@@ -27,6 +27,7 @@ import tools.vitruv.methodologist.ResponseTemplateDto;
 import tools.vitruv.methodologist.config.KeycloakAuthentication;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenByRefreshTokenRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenRequest;
+import tools.vitruv.methodologist.user.controller.dto.request.UserPostForgotPasswordRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.UserPostRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.UserPutChangePasswordRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.UserPutRequest;
@@ -127,23 +128,24 @@ public class UserController {
   }
 
   /**
-   * Sends a newly generated password to the authenticated caller's email.
+   * Initiates a password reset for the specified email address.
    *
-   * <p>Requires the caller to have the `user` role. Extracts the caller's email from the provided
-   * {@link KeycloakAuthentication}, delegates password generation and delivery to {@code
-   * userService}, and returns a response containing a success message.
+   * <p>Validates the incoming {@link UserPostForgotPasswordRequest}, delegates to {@code
+   * userService.forgotPassword(...)} to generate and send a new password, and returns a response
+   * with a success message when the email has been sent.
    *
-   * @param authentication the {@link KeycloakAuthentication} containing the caller's parsed token
-   *     and email
-   * @return a {@link ResponseTemplateDto} with no payload and a success message
-   * @throws NotFoundException if no active user is found for the caller's email (propagated from
-   *     service)
+   * @param userPostForgotPasswordRequest the validated request containing the email to reset; must
+   *     not be null or blank
+   * @return a {@link ResponseTemplateDto} with no payload and a success message ({@code
+   *     NEW_PASSWORD_SENT_SUCCESSFULLY})
+   * @throws jakarta.validation.ConstraintViolationException if validation of the request fails
+   * @throws RuntimeException if the password reset process fails (underlying exceptions will
+   *     propagate)
    */
-  @GetMapping("/v1/users/forgot-password")
-  @PreAuthorize("hasRole('user')")
-  public ResponseTemplateDto<Void> forgotPassword(KeycloakAuthentication authentication) {
-    String callerEmail = authentication.getParsedToken().getEmail();
-    userService.forgotPassword(callerEmail);
+  @PostMapping("/v1/users/forgot-password")
+  public ResponseTemplateDto<Void> forgotPassword(
+      @Valid @RequestBody UserPostForgotPasswordRequest userPostForgotPasswordRequest) {
+    userService.forgotPassword(userPostForgotPasswordRequest);
     return ResponseTemplateDto.<Void>builder().message(NEW_PASSWORD_SENT_SUCCESSFULLY).build();
   }
 

--- a/app/src/main/java/tools/vitruv/methodologist/user/controller/dto/request/UserPostForgotPasswordRequest.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/controller/dto/request/UserPostForgotPasswordRequest.java
@@ -1,0 +1,25 @@
+package tools.vitruv.methodologist.user.controller.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Request payload for initiating a password reset by email.
+ *
+ * <p>Contains the email address to send the password reset message to. Validation: must not be null
+ * or blank.
+ */
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserPostForgotPasswordRequest {
+
+  @NotNull @NotBlank private String email;
+}

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
@@ -47,6 +47,7 @@ import tools.vitruv.methodologist.exception.VerificationCodeException;
 import tools.vitruv.methodologist.user.controller.dto.KeycloakUser;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenByRefreshTokenRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenRequest;
+import tools.vitruv.methodologist.user.controller.dto.request.UserPostForgotPasswordRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.UserPostRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.UserPutChangePasswordRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.UserPutRequest;
@@ -621,7 +622,9 @@ class UserServiceTest {
 
     UserService spyService = spy(userService);
 
-    spyService.forgotPassword(email);
+    UserPostForgotPasswordRequest userPostForgotPasswordRequest =
+        UserPostForgotPasswordRequest.builder().email(email).build();
+    spyService.forgotPassword(userPostForgotPasswordRequest);
 
     verify(keycloakService).setPassword(eq(user.getUsername()), anyString());
   }
@@ -633,7 +636,9 @@ class UserServiceTest {
     when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull(email))
         .thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> userService.forgotPassword(email))
+    UserPostForgotPasswordRequest userPostForgotPasswordRequest =
+        UserPostForgotPasswordRequest.builder().email(email).build();
+    assertThatThrownBy(() -> userService.forgotPassword(userPostForgotPasswordRequest))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining(USER_EMAIL_NOT_FOUND_ERROR);
 
@@ -659,7 +664,9 @@ class UserServiceTest {
         .when(mailjetApiHandler)
         .postMail(any(), any(), any(), any(), any());
 
-    assertThatThrownBy(() -> spyService.forgotPassword(email))
+    UserPostForgotPasswordRequest userPostForgotPasswordRequest =
+        UserPostForgotPasswordRequest.builder().email(email).build();
+    assertThatThrownBy(() -> spyService.forgotPassword(userPostForgotPasswordRequest))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Mailjet failed");
 


### PR DESCRIPTION
This pull request refactors the "forgot password" functionality to use a validated request payload instead of relying on the authenticated user's email, improving both flexibility and input validation. It introduces a new DTO for the password reset request, updates the controller and service layers to use this DTO, and updates related tests accordingly.

**API and Controller Changes:**

* The `forgotPassword` endpoint now accepts a `POST` request with a `UserPostForgotPasswordRequest` payload containing the email address, instead of extracting the email from the authenticated user. The endpoint no longer requires the `user` role.
* Added the `UserPostForgotPasswordRequest` DTO, which validates that the email is not null or blank.

**Service Layer Changes:**

* The `UserService.forgotPassword` method now takes a `UserPostForgotPasswordRequest` object instead of a plain email string, and uses the email from this object.
* Refactored user creation logic to move OTP generation and email sending before Keycloak user creation, ensuring the user is saved after OTP setup. [[1]](diffhunk://#diff-f4e188c8ffe829bc350303a65dc6d963119ee88cc441d1bb8f91024aa88d237eR225-R229) [[2]](diffhunk://#diff-f4e188c8ffe829bc350303a65dc6d963119ee88cc441d1bb8f91024aa88d237eL236-L240)

**Testing Updates:**

* Updated all relevant tests in `UserServiceTest` to use the new `UserPostForgotPasswordRequest` DTO when calling `forgotPassword`. [[1]](diffhunk://#diff-e1b68e913a17ff0e2e1bfa1134f122835ef84176f1c9c708c4af30762c41d112L624-R627) [[2]](diffhunk://#diff-e1b68e913a17ff0e2e1bfa1134f122835ef84176f1c9c708c4af30762c41d112L636-R641) [[3]](diffhunk://#diff-e1b68e913a17ff0e2e1bfa1134f122835ef84176f1c9c708c4af30762c41d112L662-R669)