### PR TITLE
feat: add CI/CD workflows for production and staging deployments

### DIFF
--- a/.github/workflows/build-production.yml
+++ b/.github/workflows/build-production.yml
@@ -1,0 +1,33 @@
+name: Build - Production Image
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set tag
+        run: echo "TAG=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build backend
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/backend:$TAG ./backend
+          docker push ghcr.io/${{ github.repository }}/backend:$TAG
+
+      - name: Build frontend
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/frontend:$TAG ./frontend
+          docker push ghcr.io/${{ github.repository }}/frontend:$TAG

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -1,0 +1,47 @@
+name: CD - Staging
+
+on:
+  push:
+    branches:
+      - "release/**"
+
+jobs:
+  deploy-stage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set image tag
+        id: meta
+        run: echo "TAG=stage-${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build backend image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/backend:$TAG ./backend
+          docker push ghcr.io/${{ github.repository }}/backend:$TAG
+
+      - name: Build frontend image
+        run: |
+          docker build -t ghcr.io/${{ github.repository }}/frontend:$TAG ./frontend
+          docker push ghcr.io/${{ github.repository }}/frontend:$TAG
+
+      - name: Deploy to staging server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.STAGE_SSH_HOST }}
+          username: ${{ secrets.STAGE_SSH_USER }}
+          key: ${{ secrets.STAGE_SSH_KEY }}
+          script: |
+            cd /opt/methodologist
+            echo "BACKEND_IMAGE_TAG=$TAG" > .deploy.env
+            echo "FRONTEND_IMAGE_TAG=$TAG" >> .deploy.env
+            docker compose --env-file .deploy.env pull
+            docker compose --env-file .deploy.env up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
       - develop
+  push:
+    branches:
+      - "release/**"
   # nightly
   schedule:
     - cron: "0 3 * * *"
@@ -39,7 +42,7 @@ jobs:
           --batch-mode
           --update-snapshots
           --no-transfer-progress
-          
+
       - name: Stage build results (Unix)
         run: mkdir staging-ubuntu-latest && find . -path '*/target/*.jar' -exec cp {} staging-ubuntu-latest/ \;
 
@@ -52,7 +55,7 @@ jobs:
   sonar:
     name: SonarQube analysis
     runs-on: ubuntu-latest
-    needs: [verify]
+    needs: [ verify ]
     if: github.event_name == 'schedule' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     strategy:
       fail-fast: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,26 @@
+name: Deploy - Production (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Production version tag (e.g. v0.1.7)"
+        required: true
+
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to production
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PROD_SSH_HOST }}
+          username: ${{ secrets.PROD_SSH_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            cd /opt/methodologist
+            echo "BACKEND_IMAGE_TAG=${{ github.event.inputs.version }}" > .deploy.env
+            echo "FRONTEND_IMAGE_TAG=${{ github.event.inputs.version }}" >> .deploy.env
+            docker compose --env-file .deploy.env pull
+            docker compose --env-file .deploy.env up -d


### PR DESCRIPTION
This pull request introduces a new, streamlined CI/CD workflow for both staging and production environments using GitHub Actions. It adds separate workflows for building and deploying Docker images for the backend and frontend, and updates the CI pipeline to include release branches.

**CI/CD Workflow Additions and Improvements:**

* Added a new workflow `.github/workflows/build-production.yml` to automatically build and push production Docker images for both backend and frontend when a version tag is pushed.
* Introduced `.github/workflows/cd-staging.yml` to build and push Docker images on pushes to `release/**` branches and deploy them to the staging server via SSH.
* Created `.github/workflows/deploy-production.yml` for manual production deployments, allowing a specific version tag to be deployed to the production server via SSH.

**CI Pipeline Update:**

* Updated `.github/workflows/ci.yml` to trigger the CI workflow on pushes to `release/**` branches, in addition to the existing branches.