### PR TITLE
Merge develop into main

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/messages/Error.java
+++ b/app/src/main/java/tools/vitruv/methodologist/messages/Error.java
@@ -2,7 +2,7 @@ package tools.vitruv.methodologist.messages;
 
 /** Contains error message constants used throughout the application. */
 public class Error {
-  public static final String CLIENT_NOT_FOUND_ERROR = "Client not found";
+  public static final String CLIENT_NOT_FOUND_ERROR = "Client";
   public static final String USER_ID_NOT_FOUND_ERROR = "User id";
   public static final String VSUM_ID_NOT_FOUND_ERROR = "Vsum id";
   public static final String VSUM_HISTORY_ID_NOT_FOUND_ERROR = "Vsum history id";
@@ -13,9 +13,9 @@ public class Error {
   public static final String USER_WRONG_PASSWORD_ERROR = "Wrong password";
   public static final String META_MODEL_ID_NOT_FOUND_ERROR = "Meta model id";
   public static final String FILE_HASHING_EXCEPTION = "Failed to compute SHA-256 hash";
-  public static final String REACTION_FILE_IDS_ID_NOT_FOUND_ERROR = "Reaction files not found";
-  public static final String MEMBER_IN_VSUM_NOT_FOUND_ERROR = "Member in VSUM not found.";
-  public static final String FILE_ID_NOT_FOUND_ERROR = "File not found.";
+  public static final String REACTION_FILE_IDS_ID_NOT_FOUND_ERROR = "Reaction files";
+  public static final String MEMBER_IN_VSUM_NOT_FOUND_ERROR = "Member in VSUM";
+  public static final String FILE_ID_NOT_FOUND_ERROR = "File";
   public static final String METAMODEL_PAIR_COUNT_MISMATCH_ERROR =
       "Number of Ecore files must match number of GenModel files";
   public static final String METAMODEL_PAIR_REQUIRED_ERROR =


### PR DESCRIPTION
This pull request updates several error message constants in the `Error` class to use shorter, more generic strings instead of full descriptive messages. This change likely aims to standardize error handling or defer the construction of full error messages to another part of the application.

Error message constant updates:

* Shortened the values of `CLIENT_NOT_FOUND_ERROR`, `REACTION_FILE_IDS_ID_NOT_FOUND_ERROR`, `MEMBER_IN_VSUM_NOT_FOUND_ERROR`, and `FILE_ID_NOT_FOUND_ERROR` to be more generic (e.g., "Client" instead of "Client not found") in `Error.java`. [[1]](diffhunk://#diff-50608b086def86b21c7f70b39d83b3f8d25397f2f970e74da49efb7f14ff59c1L5-R5) [[2]](diffhunk://#diff-50608b086def86b21c7f70b39d83b3f8d25397f2f970e74da49efb7f14ff59c1L16-R18)