### PR TITLE
feat: implement user synchronization with Keycloak in UserService and…

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/config/SecurityConfiguration.java
+++ b/app/src/main/java/tools/vitruv/methodologist/config/SecurityConfiguration.java
@@ -4,16 +4,19 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import tools.vitruv.methodologist.user.service.UserService;
 
 /**
  * Spring Security configuration for the application.
@@ -26,11 +29,22 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableMethodSecurity(jsr250Enabled = true, prePostEnabled = true)
 public class SecurityConfiguration {
 
+  private final UserService userService;
+
   @Value("${allowed.origins:*}")
   private String allowedOrigins;
 
   @Value("${allowed.headers:*}")
   private String allowedHeaders;
+
+  /**
+   * Constructs a new SecurityConfiguration.
+   *
+   * @param userService the {@link UserService} used for user synchronization and related logic.
+   */
+  public SecurityConfiguration(UserService userService) {
+    this.userService = userService;
+  }
 
   /**
    * Defines the security filter chain:
@@ -56,28 +70,24 @@ public class SecurityConfiguration {
                 auth.requestMatchers(HttpMethod.OPTIONS, "/**")
                     .permitAll()
                     .anyRequest()
-                    .permitAll() // while debugging
-            )
+                    .permitAll())
         .oauth2ResourceServer(
-            oauth2 ->
-                oauth2.jwt(
-                    jwt ->
-                        jwt.jwtAuthenticationConverter(new KeycloakJwtAuthenticationConverter())))
+            oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(customJwtConverter())))
         .build();
   }
 
-  /**
-   * Creates and configures a {@link JwtAuthenticationConverter} that delegates extraction of
-   * granted authorities to {@link GrantedAuthoritiesConverter}.
-   *
-   * <p>Used when a plain {@link JwtAuthenticationConverter} instance is required.
-   *
-   * @return a configured {@link JwtAuthenticationConverter}
-   */
-  private JwtAuthenticationConverter jwtAuthenticationConverter() {
-    var conv = new JwtAuthenticationConverter();
-    conv.setJwtGrantedAuthoritiesConverter(new GrantedAuthoritiesConverter());
-    return conv;
+  private Converter<Jwt, ? extends AbstractAuthenticationToken> customJwtConverter() {
+    return jwt -> {
+      userService.syncWithKeycloak(
+          jwt.getClaimAsString("email"),
+          jwt.getClaimAsString("preferred_username"),
+          jwt.getClaimAsString("given_name"),
+          jwt.getClaimAsString("family_name"));
+
+      var grantedAuthoritiesConverter = new GrantedAuthoritiesConverter();
+      var authorities = grantedAuthoritiesConverter.convert(jwt);
+      return new KeycloakAuthentication(jwt, authorities);
+    };
   }
 
   /**

--- a/app/src/main/java/tools/vitruv/methodologist/user/model/repository/UserRepository.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/model/repository/UserRepository.java
@@ -106,8 +106,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
    * Finds a non-deleted user by username, ignoring case.
    *
    * @param email the username to search for (case-insensitive)
-   * @return an {@link java.util.Optional} containing the user if found and not removed,
-   *     otherwise empty
+   * @return an {@link java.util.Optional} containing the user if found and not removed, otherwise
+   *     empty
    */
   Optional<User> findByUsernameIgnoreCaseAndRemovedAtIsNull(String email);
 }

--- a/app/src/main/java/tools/vitruv/methodologist/user/model/repository/UserRepository.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/model/repository/UserRepository.java
@@ -101,4 +101,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
       @Param("callerEmail") String callerEmail,
       @Param("queryParam") String queryParam,
       Pageable pageable);
+
+  /**
+   * Finds a non-deleted user by username, ignoring case.
+   *
+   * @param email the username to search for (case-insensitive)
+   * @return an {@link java.util.Optional} containing the user if found and not removed,
+   *     otherwise empty
+   */
+  Optional<User> findByUsernameIgnoreCaseAndRemovedAtIsNull(String email);
 }

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
@@ -7,6 +7,7 @@ import static tools.vitruv.methodologist.messages.Error.USER_ID_NOT_FOUND_ERROR;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
@@ -27,6 +28,7 @@ import tools.vitruv.methodologist.exception.ValidationCodeExpiredException;
 import tools.vitruv.methodologist.exception.ValidationCodeNotExpiredYetException;
 import tools.vitruv.methodologist.exception.VerificationCodeException;
 import tools.vitruv.methodologist.general.service.SmtpMailService;
+import tools.vitruv.methodologist.user.RoleType;
 import tools.vitruv.methodologist.user.controller.dto.KeycloakUser;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenByRefreshTokenRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenRequest;
@@ -228,6 +230,104 @@ public class UserService {
             .build();
     keycloakService.createUser(keycloakUser);
     return user;
+  }
+
+  /**
+   * Synchronizes a user account with Keycloak, creating or updating the user as needed.
+   *
+   * <p>Searches for an existing, non-removed user by username. If found, updates the user's email,
+   * first name, and last name with the provided values. If not found, creates a new user with the
+   * provided credentials, marking them as verified by default with the USER role.
+   *
+   * <p>After the user is persisted, the Keycloak user role is assigned or updated for the given
+   * username to synchronize role information across systems.
+   *
+   * <p>This method is transactional and ensures atomic creation/update of the user entity and role
+   * assignment.
+   *
+   * @param email the email address of the user to sync or create
+   * @param username the unique username of the user to sync or create (used for lookup and role
+   *     assignment)
+   * @param firstName the first name of the user
+   * @param lastName the last name of the user
+   * @throws IllegalArgumentException if any parameter is null
+   * @see KeycloakService#assignUserRole(String, String)
+   */
+  @Transactional
+  public void syncWithKeycloak(String email, String username, String firstName, String lastName) {
+    validateSyncParameters(email, username, firstName, lastName);
+
+    Optional<User> existingUser =
+        userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username);
+
+    User userToSave =
+        existingUser
+            .map(user -> updateExistingUser(user, email, firstName, lastName))
+            .orElseGet(() -> createNewUser(email, username, firstName, lastName));
+
+    userRepository.save(userToSave);
+    keycloakService.assignUserRole(username, userToSave.getRoleType().getName());
+  }
+
+  /**
+   * Validates the required parameters for the sync with Keycloak operation.
+   *
+   * @param email the email address to validate
+   * @param username the username to validate
+   * @param firstName the first name to validate
+   * @param lastName the last name to validate
+   * @throws IllegalArgumentException if any parameter is null or blank
+   */
+  private void validateSyncParameters(
+      String email, String username, String firstName, String lastName) {
+    if (email == null || email.isBlank()) {
+      throw new IllegalArgumentException("Email cannot be null or blank");
+    }
+    if (username == null || username.isBlank()) {
+      throw new IllegalArgumentException("Username cannot be null or blank");
+    }
+    if (firstName == null || firstName.isBlank()) {
+      throw new IllegalArgumentException("FirstName cannot be null or blank");
+    }
+    if (lastName == null || lastName.isBlank()) {
+      throw new IllegalArgumentException("LastName cannot be null or blank");
+    }
+  }
+
+  /**
+   * Updates an existing user with the provided information.
+   *
+   * @param user the existing user to update
+   * @param email the new email address
+   * @param firstName the new first name
+   * @param lastName the new last name
+   * @return the updated user entity
+   */
+  private User updateExistingUser(User user, String email, String firstName, String lastName) {
+    user.setEmail(email);
+    user.setFirstName(firstName);
+    user.setLastName(lastName);
+    return user;
+  }
+
+  /**
+   * Creates a new user with the provided information, marked as verified by default with USER role.
+   *
+   * @param email the email address for the new user
+   * @param username the username for the new user
+   * @param firstName the first name for the new user
+   * @param lastName the last name for the new user
+   * @return a new user entity (not yet persisted)
+   */
+  private User createNewUser(String email, String username, String firstName, String lastName) {
+    return User.builder()
+        .email(email)
+        .firstName(firstName)
+        .lastName(lastName)
+        .username(username)
+        .verified(Boolean.TRUE)
+        .roleType(RoleType.USER)
+        .build();
   }
 
   /**

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
@@ -756,14 +756,10 @@ class UserServiceTest {
 
   @Test
   void syncWithKeycloak_updatesExistingUser_whenUsernameFound() {
-    String newEmail = "updatedemail@example.com";
-    String username = "existinguser";
-    String newFirstName = "Jane";
-    String newLastName = "Smith";
-
     User existingUser = new User();
     existingUser.setId(1L);
     existingUser.setEmail("oldemail@example.com");
+    String username = "existinguser";
     existingUser.setUsername(username);
     existingUser.setFirstName("Old");
     existingUser.setLastName("Name");
@@ -773,6 +769,9 @@ class UserServiceTest {
     when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
         .thenReturn(Optional.of(existingUser));
 
+    String newEmail = "updatedemail@example.com";
+    String newFirstName = "Jane";
+    String newLastName = "Smith";
     userService.syncWithKeycloak(newEmail, username, newFirstName, newLastName);
 
     ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
@@ -924,7 +923,6 @@ class UserServiceTest {
 
   @Test
   void syncWithKeycloak_usernameSearchIsCaseInsensitive() {
-    String username = "JohnDoe";
     User existing = new User();
     existing.setId(1L);
     existing.setEmail("john@example.com");
@@ -933,6 +931,7 @@ class UserServiceTest {
     existing.setLastName("Doe");
     existing.setRoleType(RoleType.USER);
 
+    String username = "JohnDoe";
     when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
         .thenReturn(Optional.of(existing));
 

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
@@ -44,6 +44,7 @@ import tools.vitruv.methodologist.exception.ValidationCodeExpiredException;
 import tools.vitruv.methodologist.exception.ValidationCodeNotExpiredYetException;
 import tools.vitruv.methodologist.exception.VerificationCodeException;
 import tools.vitruv.methodologist.general.service.SmtpMailService;
+import tools.vitruv.methodologist.user.RoleType;
 import tools.vitruv.methodologist.user.controller.dto.KeycloakUser;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenByRefreshTokenRequest;
 import tools.vitruv.methodologist.user.controller.dto.request.PostAccessTokenRequest;
@@ -725,5 +726,277 @@ class UserServiceTest {
     assertThatThrownBy(() -> userService.changePassword(email, req))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Keycloak down");
+  }
+
+  @Test
+  void syncWithKeycloak_createsNewUser_whenUsernameNotFound() {
+    String email = "newuser@example.com";
+    String username = "newuser";
+    String firstName = "John";
+    String lastName = "Doe";
+
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.empty());
+
+    userService.syncWithKeycloak(email, username, firstName, lastName);
+
+    ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository).save(savedCaptor.capture());
+
+    User savedUser = savedCaptor.getValue();
+    assertThat(savedUser.getEmail()).isEqualTo(email);
+    assertThat(savedUser.getUsername()).isEqualTo(username);
+    assertThat(savedUser.getFirstName()).isEqualTo(firstName);
+    assertThat(savedUser.getLastName()).isEqualTo(lastName);
+    assertThat(savedUser.getVerified()).isTrue();
+    assertThat(savedUser.getRoleType()).isEqualTo(RoleType.USER);
+
+    verify(keycloakService).assignUserRole(username, RoleType.USER.getName());
+  }
+
+  @Test
+  void syncWithKeycloak_updatesExistingUser_whenUsernameFound() {
+    String newEmail = "updatedemail@example.com";
+    String username = "existinguser";
+    String newFirstName = "Jane";
+    String newLastName = "Smith";
+
+    User existingUser = new User();
+    existingUser.setId(1L);
+    existingUser.setEmail("oldemail@example.com");
+    existingUser.setUsername(username);
+    existingUser.setFirstName("Old");
+    existingUser.setLastName("Name");
+    existingUser.setVerified(true);
+    existingUser.setRoleType(RoleType.USER);
+
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.of(existingUser));
+
+    userService.syncWithKeycloak(newEmail, username, newFirstName, newLastName);
+
+    ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository).save(savedCaptor.capture());
+
+    User savedUser = savedCaptor.getValue();
+    assertThat(savedUser.getId()).isEqualTo(1L);
+    assertThat(savedUser.getEmail()).isEqualTo(newEmail);
+    assertThat(savedUser.getUsername()).isEqualTo(username);
+    assertThat(savedUser.getFirstName()).isEqualTo(newFirstName);
+    assertThat(savedUser.getLastName()).isEqualTo(newLastName);
+    assertThat(savedUser.getVerified()).isTrue();
+
+    verify(keycloakService).assignUserRole(username, RoleType.USER.getName());
+  }
+
+  @Test
+  void syncWithKeycloak_preservesUserIdAndVerifiedStatus_whenUpdating() {
+    String username = "user123";
+    User existingUser = new User();
+    existingUser.setId(99L);
+    existingUser.setVerified(true);
+    existingUser.setEmail("old@example.com");
+    existingUser.setUsername(username);
+    existingUser.setFirstName("Old");
+    existingUser.setLastName("Value");
+    existingUser.setRoleType(RoleType.USER);
+
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.of(existingUser));
+
+    userService.syncWithKeycloak("new@example.com", username, "New", "Value");
+
+    ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository).save(savedCaptor.capture());
+
+    User saved = savedCaptor.getValue();
+    assertThat(saved.getId()).isEqualTo(99L);
+    assertThat(saved.getVerified()).isTrue();
+  }
+
+  @Test
+  void syncWithKeycloak_callsKeycloakRoleAssignment_forNewUser() {
+    String username = "newuser";
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.empty());
+
+    userService.syncWithKeycloak("new@example.com", username, "John", "Doe");
+
+    verify(keycloakService).assignUserRole(username, "user");
+  }
+
+  @Test
+  void syncWithKeycloak_callsKeycloakRoleAssignment_forExistingUser() {
+    String username = "existinguser";
+    User existing = new User();
+    existing.setId(1L);
+    existing.setEmail("old@example.com");
+    existing.setUsername(username);
+    existing.setFirstName("Old");
+    existing.setLastName("Name");
+    existing.setRoleType(RoleType.USER);
+
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.of(existing));
+
+    userService.syncWithKeycloak("new@example.com", username, "John", "Doe");
+
+    verify(keycloakService).assignUserRole(username, "user");
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenEmailNull() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak(null, "username", "John", "Doe"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Email cannot be null or blank");
+
+    verify(userRepository, never()).findByUsernameIgnoreCaseAndRemovedAtIsNull(anyString());
+    verify(userRepository, never()).save(any());
+    verify(keycloakService, never()).assignUserRole(anyString(), anyString());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenEmailBlank() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("  ", "username", "John", "Doe"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Email cannot be null or blank");
+
+    verify(userRepository, never()).findByUsernameIgnoreCaseAndRemovedAtIsNull(anyString());
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenUsernameNull() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("john@example.com", null, "John", "Doe"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Username cannot be null or blank");
+
+    verify(userRepository, never()).save(any());
+    verify(keycloakService, never()).assignUserRole(anyString(), anyString());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenUsernameBlank() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("john@example.com", "   ", "John", "Doe"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Username cannot be null or blank");
+
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenFirstNameNull() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("john@example.com", "john", null, "Doe"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("FirstName cannot be null or blank");
+
+    verify(userRepository, never()).save(any());
+    verify(keycloakService, never()).assignUserRole(anyString(), anyString());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenFirstNameBlank() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("john@example.com", "john", "  ", "Doe"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("FirstName cannot be null or blank");
+
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenLastNameNull() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("john@example.com", "john", "John", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("LastName cannot be null or blank");
+
+    verify(userRepository, never()).save(any());
+    verify(keycloakService, never()).assignUserRole(anyString(), anyString());
+  }
+
+  @Test
+  void syncWithKeycloak_throwsIllegalArgumentException_whenLastNameBlank() {
+    assertThatThrownBy(() -> userService.syncWithKeycloak("john@example.com", "john", "John", "  "))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("LastName cannot be null or blank");
+
+    verify(userRepository, never()).save(any());
+  }
+
+  @Test
+  void syncWithKeycloak_usernameSearchIsCaseInsensitive() {
+    String username = "JohnDoe";
+    User existing = new User();
+    existing.setId(1L);
+    existing.setEmail("john@example.com");
+    existing.setUsername("johndoe");
+    existing.setFirstName("John");
+    existing.setLastName("Doe");
+    existing.setRoleType(RoleType.USER);
+
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.of(existing));
+
+    userService.syncWithKeycloak("newemail@example.com", username, "John", "Doe");
+
+    verify(userRepository).findByUsernameIgnoreCaseAndRemovedAtIsNull(username);
+    verify(keycloakService).assignUserRole(username, "user");
+  }
+
+  @Test
+  void syncWithKeycloak_doesNotUpdateRemovedUsers() {
+    String username = "removeduser";
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.empty());
+
+    userService.syncWithKeycloak("new@example.com", username, "John", "Doe");
+
+    ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository).save(savedCaptor.capture());
+
+    User savedUser = savedCaptor.getValue();
+    assertThat(savedUser.getRemovedAt()).isNull();
+  }
+
+  @Test
+  void syncWithKeycloak_newUserHasUserRoleByDefault() {
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull("newuser"))
+        .thenReturn(Optional.empty());
+
+    userService.syncWithKeycloak("user@example.com", "newuser", "Test", "User");
+
+    ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
+    verify(userRepository).save(savedCaptor.capture());
+
+    assertThat(savedCaptor.getValue().getRoleType()).isEqualTo(RoleType.USER);
+  }
+
+  @Test
+  void syncWithKeycloak_propagatesRepositorySaveException() {
+    String username = "erroruser";
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.empty());
+    doThrow(new RuntimeException("Database error")).when(userRepository).save(any());
+
+    assertThatThrownBy(
+            () -> userService.syncWithKeycloak("error@example.com", username, "John", "Doe"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Database error");
+
+    verify(keycloakService, never()).assignUserRole(anyString(), anyString());
+  }
+
+  @Test
+  void syncWithKeycloak_propagatesKeycloakRoleAssignmentException() {
+    String username = "keycloakerror";
+    when(userRepository.findByUsernameIgnoreCaseAndRemovedAtIsNull(username))
+        .thenReturn(Optional.empty());
+    doThrow(new RuntimeException("Keycloak service down"))
+        .when(keycloakService)
+        .assignUserRole(username, "user");
+
+    assertThatThrownBy(
+            () -> userService.syncWithKeycloak("error@example.com", username, "John", "Doe"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Keycloak service down");
   }
 }


### PR DESCRIPTION
This pull request introduces a robust user synchronization mechanism with Keycloak, ensuring that user data is kept consistent between the application and the identity provider. The main changes include implementing a new `syncWithKeycloak` method in the `UserService`, updating the security configuration to call this method during JWT authentication, extending repository functionality, and adding comprehensive unit tests for the new logic.

**Keycloak User Synchronization**

* Added the `syncWithKeycloak` method to `UserService`, which creates or updates a user based on Keycloak-provided JWT claims, ensures required fields are present, and synchronizes user roles with Keycloak. This method is transactional and handles both new and existing users, including validation and error handling.
* Updated `UserRepository` with a new method `findByUsernameIgnoreCaseAndRemovedAtIsNull` to support case-insensitive and non-deleted user lookups for synchronization.

**Security Configuration Updates**

* Modified `SecurityConfiguration` to inject `UserService` and invoke `syncWithKeycloak` during JWT authentication, ensuring user data is synchronized on every authenticated request. Replaced the previous JWT converter with a custom converter that triggers the sync logic. [[1]](diffhunk://#diff-9353861e27fc3d387d980d36fdf48ff009b9168e1e29f50a313e74331474c68fR7-R19) [[2]](diffhunk://#diff-9353861e27fc3d387d980d36fdf48ff009b9168e1e29f50a313e74331474c68fR32-R48) [[3]](diffhunk://#diff-9353861e27fc3d387d980d36fdf48ff009b9168e1e29f50a313e74331474c68fL59-R90)

**Testing**

* Added extensive unit tests in `UserServiceTest` to cover all branches of the new synchronization logic, including user creation, updates, validation errors, case-insensitive lookups, and error propagation from repository and Keycloak service.

**Minor Dependency and Import Updates**

* Updated import statements to support the new logic and ensure all dependencies are included. [[1]](diffhunk://#diff-f4e188c8ffe829bc350303a65dc6d963119ee88cc441d1bb8f91024aa88d237eR10) [[2]](diffhunk://#diff-f4e188c8ffe829bc350303a65dc6d963119ee88cc441d1bb8f91024aa88d237eR31) [[3]](diffhunk://#diff-e1b68e913a17ff0e2e1bfa1134f122835ef84176f1c9c708c4af30762c41d112R47)

Closes #231 