### PR TITLE
skip SMTP delivery in non-production environments

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/general/service/SmtpMailService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/general/service/SmtpMailService.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mail.MailException;
@@ -23,9 +25,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class SmtpMailService {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(SmtpMailService.class);
+
   private final JavaMailSender mailSender;
   private final String fromEmail;
   private final String fromName;
+  private final boolean noProduction;
 
   /**
    * Constructs the SMTP mail service and configures the underlying JavaMail sender.
@@ -41,6 +46,7 @@ public class SmtpMailService {
    * @param connectionTimeoutMs connection timeout in milliseconds
    * @param timeoutMs read timeout in milliseconds
    * @param writeTimeoutMs write timeout in milliseconds
+   * @param noProduction whether external email delivery is disabled for non-production
    * @throws NullPointerException if {@code fromEmail} or {@code fromName} is {@code null}
    */
   public SmtpMailService(
@@ -54,9 +60,11 @@ public class SmtpMailService {
       @Value("${mail.smtp.ssl:false}") boolean ssl,
       @Value("${mail.smtp.connectionTimeoutMs:10000}") int connectionTimeoutMs,
       @Value("${mail.smtp.timeoutMs:10000}") int timeoutMs,
-      @Value("${mail.smtp.writeTimeoutMs:10000}") int writeTimeoutMs) {
+      @Value("${mail.smtp.writeTimeoutMs:10000}") int writeTimeoutMs,
+      @Value("${deploy.noProduction:false}") boolean noProduction) {
     this.fromEmail = Objects.requireNonNull(fromEmail);
     this.fromName = Objects.requireNonNull(fromName);
+    this.noProduction = noProduction;
 
     JavaMailSenderImpl impl = new JavaMailSenderImpl();
     impl.setHost(host);
@@ -89,6 +97,15 @@ public class SmtpMailService {
    * @throws RuntimeException if reading the template or sending the message fails
    */
   public void sendOtpMail(String toEmail, String toName, String otpCode, int ttlMinutes) {
+    if (noProduction) {
+      LOGGER.info(
+          "SMTP disabled in non-production; OTP for {} is {} and expires in {} minutes",
+          toEmail,
+          otpCode,
+          ttlMinutes);
+      return;
+    }
+
     String subject = "Verify your email";
     String html =
         loadAndRenderTemplate(
@@ -111,6 +128,12 @@ public class SmtpMailService {
    * @throws RuntimeException if reading the template or sending the message fails
    */
   public void sendForgotPasswordMail(String toEmail, String toName, String newPassword) {
+    if (noProduction) {
+      LOGGER.info(
+          "SMTP disabled in non-production; generated password for {} is {}", toEmail, newPassword);
+      return;
+    }
+
     String subject = "Your new password";
     String html =
         loadAndRenderTemplate(
@@ -133,6 +156,15 @@ public class SmtpMailService {
    */
   public void sendVsumInvitationMail(
       String toEmail, String toName, String vsumName, String invitationLink) {
+    if (noProduction) {
+      LOGGER.info(
+          "SMTP disabled in non-production; VSUM invitation for {} to '{}' is {}",
+          toEmail,
+          safe(vsumName),
+          safe(invitationLink));
+      return;
+    }
+
     String subject = "You have been invited to a VSUM";
     String html =
         loadAndRenderTemplate(

--- a/app/src/test/java/tools/vitruv/methodologist/general/service/SmtpMailServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/general/service/SmtpMailServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.mail.internet.MimeMessage;
@@ -57,7 +58,8 @@ public class SmtpMailServiceTest {
             ssl,
             connectionTimeoutMs,
             timeoutMs,
-            writeTimeoutMs);
+            writeTimeoutMs,
+            false);
 
     mailSender = mock(JavaMailSender.class);
     ReflectionTestUtils.setField(smtpMailService, "mailSender", mailSender);
@@ -73,7 +75,18 @@ public class SmtpMailServiceTest {
         NullPointerException.class,
         () ->
             new SmtpMailService(
-                "localhost", 587, "user", "pass", null, "Name", true, false, 5000, 5000, 5000));
+                "localhost",
+                587,
+                "user",
+                "pass",
+                null,
+                "Name",
+                true,
+                false,
+                5000,
+                5000,
+                5000,
+                false));
   }
 
   @Test
@@ -92,7 +105,8 @@ public class SmtpMailServiceTest {
                 false,
                 5000,
                 5000,
-                5000));
+                5000,
+                false));
   }
 
   // sendOtpMail -> happy paths
@@ -105,6 +119,27 @@ public class SmtpMailServiceTest {
         () -> smtpMailService.sendOtpMail(recipientEmail, recipientName, "123456", 5));
 
     verify(mailSender, times(1)).send(mimeMessageMock);
+  }
+
+  @Test
+  void noProductionMode_doesNotUseSmtp() {
+    SmtpMailService nonProductionService =
+        new SmtpMailService(
+            "localhost", 587, "", "", "from@test.com", "Name", true, false, 5000, 5000, 5000, true);
+    ReflectionTestUtils.setField(nonProductionService, "mailSender", mailSender);
+
+    assertDoesNotThrow(
+        () -> nonProductionService.sendOtpMail(recipientEmail, recipientName, "123456", 5));
+    assertDoesNotThrow(
+        () ->
+            nonProductionService.sendForgotPasswordMail(
+                recipientEmail, recipientName, "new-secure-pass"));
+    assertDoesNotThrow(
+        () ->
+            nonProductionService.sendVsumInvitationMail(
+                recipientEmail, recipientName, "VSUM", "http://localhost/vsum/1"));
+
+    verifyNoInteractions(mailSender);
   }
 
   @Test


### PR DESCRIPTION
## Summary

Prevents user sign-up from failing in non-production environments when the external SMTP server is unavailable.

## Problem

The backend attempted to connect to `smarthost.kit.edu` during local sign-up. When the server was unreachable, the request returned HTTP 500 before the user was created.

## Changes

- Use the existing `deploy.noProduction` flag to disable external email delivery outside production.
- Log OTP codes, generated passwords, and VSUM invitation links for local testing.
- Preserve the existing authenticated SMTP behavior in production.
- Add tests confirming that the mail sender is not called in non-production mode.
- Leave `application-dev.properties` unchanged.

## Testing

- SMTP service tests pass.
- Full backend test suite passes: **330 tests, 0 failures**.
- Verified that the local backend starts successfully and responds on port `9811`.