### PR TITLE
Require current password for password changes

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/exception/GlobalExceptionHandlerController.java
+++ b/app/src/main/java/tools/vitruv/methodologist/exception/GlobalExceptionHandlerController.java
@@ -16,6 +16,7 @@
 
 package tools.vitruv.methodologist.exception;
 
+import jakarta.ws.rs.BadRequestException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -463,6 +464,31 @@ public class GlobalExceptionHandlerController {
       HttpClientErrorException.BadRequest ex,
       HandlerMethod handlerMethod,
       ServletWebRequest request) {
+    log.warn(
+        BAD_REQUEST_ERROR,
+        handlerMethod.getMethod().getDeclaringClass().getSimpleName(),
+        ex.getMessage());
+    log.debug(STACKTRACE_LOG, ex.toString());
+    return ErrorResponse.builder()
+        .error(BAD_REQUEST_ERROR)
+        .message(Objects.requireNonNull(ex.getMessage()))
+        .path(getPath(request))
+        .build();
+  }
+
+  /**
+   * Handles bad request exceptions from JAX-RS operations.
+   *
+   * @param ex the caught BadRequest exception
+   * @param handlerMethod the handler method that threw the exception
+   * @param request the current web request
+   * @return ErrorResponse with bad request details
+   */
+  @ExceptionHandler(value = BadRequestException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseBody
+  public ErrorResponse badRequestException(
+      BadRequestException ex, HandlerMethod handlerMethod, ServletWebRequest request) {
     log.warn(
         BAD_REQUEST_ERROR,
         handlerMethod.getMethod().getDeclaringClass().getSimpleName(),

--- a/app/src/main/java/tools/vitruv/methodologist/log/RequestResponseLoggingFilter.java
+++ b/app/src/main/java/tools/vitruv/methodologist/log/RequestResponseLoggingFilter.java
@@ -40,6 +40,7 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
   private static final Set<String> SENSITIVE_KEYS =
       Set.of(
           "password",
+          "currentpassword",
           "newpassword",
           "oldpassword",
           "confirmpassword",
@@ -305,14 +306,17 @@ public class RequestResponseLoggingFilter extends OncePerRequestFilter {
   private String redactWithRegex(String raw) {
     return raw.replaceAll("(?i)(\"password\"\\s*:\\s*\")[^\"]*(\")", "$1" + MASK + "$2")
         .replaceAll(
-            "(?i)(\"(newPassword|oldPassword|confirmPassword)\"\\s*:\\s*\")[^\"]*(\")",
+            "(?i)(\"(currentPassword|newPassword|oldPassword|confirmPassword)"
+                + "\"\\s*:\\s*\")[^\"]*(\")",
             "$1" + MASK + "$3")
         .replaceAll(
             "(?i)(\"(accessToken|refreshToken|token|access_token|refresh_token|id_token)"
                 + "\"\\s*:\\s*\")[^\"]*(\")",
             "$1" + MASK + "$3")
         .replaceAll(
-            "(?i)(password|accessToken|refreshToken|access_token|refresh_token)=\\S+", "$1=" + MASK)
+            "(?i)(currentPassword|newPassword|oldPassword|confirmPassword|password|accessToken"
+                + "|refreshToken|access_token|refresh_token)=[^\\s&]+",
+            "$1=" + MASK)
         .replaceAll("(?i)(Authorization\\s*:\\s*Bearer\\s+)[A-Z0-9._~-]+", "$1" + MASK);
   }
 }

--- a/app/src/main/java/tools/vitruv/methodologist/user/controller/UserController.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/controller/UserController.java
@@ -158,7 +158,8 @@ public class UserController {
    *
    * @param authentication the {@link KeycloakAuthentication} containing the caller's parsed token
    *     and email
-   * @param userPutChangePasswordRequest validated request DTO containing the new password
+   * @param userPutChangePasswordRequest validated request DTO containing the current and new
+   *     password
    * @return a {@link ResponseTemplateDto} with no payload and a success message
    * @throws RuntimeException if the service fails to change the password (underlying exceptions
    *     will propagate)

--- a/app/src/main/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequest.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequest.java
@@ -13,9 +13,9 @@ import lombok.Setter;
 /**
  * Request DTO for changing a user's password.
  *
- * <p>Contains a single write-only {@code password} field. Validation enforces a strong password
- * policy: at least 8 characters, with at least one uppercase letter, one lowercase letter, one
- * digit and one special character.
+ * <p>Contains write-only current and new password fields. Validation enforces a strong password
+ * policy for the new password: at least 8 characters, with at least one uppercase letter, one
+ * lowercase letter, one digit and one special character.
  */
 @Getter
 @Setter
@@ -27,13 +27,18 @@ public class UserPutChangePasswordRequest {
   @NotNull
   @NotBlank
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+  private String currentPassword;
+
+  @NotNull
+  @NotBlank
+  @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   @Pattern(
       regexp = "^(?=.{8,256}$)(?=.*\\p{Ll})(?=.*\\p{Lu})(?=.*\\p{Nd})(?=.*[^\\p{L}\\p{Nd}\\s]).*$",
       message = "The password needs to be at least 8 characters long.")
-  private String password;
+  private String newPassword;
 
   @Override
   public String toString() {
-    return "UserPutChangePasswordRequest(password=****)";
+    return "UserPutChangePasswordRequest(currentPassword=****, newPassword=****)";
   }
 }

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
@@ -442,16 +442,17 @@ public class UserService {
   /**
    * Changes the password of the active user identified by the provided email.
    *
-   * <p>Looks up an active (not removed) user by email, then delegates the password update to {@code
-   * keycloakService.setPassword}. The provided {@link UserPutChangePasswordRequest} is expected to
-   * be validated before calling this method (see its {@code @Pattern} constraint for password
-   * requirements).
+   * <p>Looks up an active (not removed) user by email, verifies the provided current password
+   * against Keycloak, then delegates the password update to {@code keycloakService.setPassword}.
+   * The provided {@link UserPutChangePasswordRequest} is expected to be validated before calling
+   * this method (see its {@code @Pattern} constraint for password requirements).
    *
    * <p>The operation is executed within a transaction but does not modify the application user
    * entity in the database — only the Keycloak credential is updated.
    *
    * @param email the case-insensitive email address of the user whose password will be changed
-   * @param userPutChangePasswordRequest the validated request DTO containing the new password
+   * @param userPutChangePasswordRequest the validated request DTO containing the current and new
+   *     password
    * @throws NotFoundException if no active user is found for the given email
    */
   @Transactional
@@ -461,7 +462,9 @@ public class UserService {
         userRepository
             .findByEmailIgnoreCaseAndRemovedAtIsNull(email)
             .orElseThrow(() -> new NotFoundException(USER_EMAIL_NOT_FOUND_ERROR));
-    keycloakService.setPassword(user.getUsername(), userPutChangePasswordRequest.getPassword());
+    keycloakService.verifyUserPasswordOrThrow(
+        user.getUsername(), userPutChangePasswordRequest.getCurrentPassword());
+    keycloakService.setPassword(user.getUsername(), userPutChangePasswordRequest.getNewPassword());
   }
 
   /**

--- a/app/src/test/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequestTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequestTest.java
@@ -1,0 +1,67 @@
+package tools.vitruv.methodologist.user.controller.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.Pattern;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class UserPutChangePasswordRequestTest {
+
+  private static ValidatorFactory validatorFactory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUpValidator() {
+    validatorFactory = Validation.buildDefaultValidatorFactory();
+    validator = validatorFactory.getValidator();
+  }
+
+  @AfterAll
+  static void closeValidatorFactory() {
+    validatorFactory.close();
+  }
+
+  @Test
+  void validate_fails_whenCurrentPasswordIsMissing() {
+    UserPutChangePasswordRequest request =
+        UserPutChangePasswordRequest.builder().newPassword("StrongPass#12345").build();
+
+    assertThat(validator.validate(request))
+        .anySatisfy(
+            violation ->
+                assertThat(violation.getPropertyPath().toString()).isEqualTo("currentPassword"));
+  }
+
+  @Test
+  void validate_fails_whenNewPasswordViolatesExistingPasswordRules() {
+    UserPutChangePasswordRequest request =
+        UserPutChangePasswordRequest.builder()
+            .currentPassword("CurrentPass#12345")
+            .newPassword("weak")
+            .build();
+
+    assertThat(validator.validate(request))
+        .anySatisfy(
+            violation -> {
+              assertThat(violation.getPropertyPath().toString()).isEqualTo("newPassword");
+              assertThat(violation.getConstraintDescriptor().getAnnotation())
+                  .isInstanceOf(Pattern.class);
+            });
+  }
+
+  @Test
+  void validate_passes_whenCurrentPasswordExists_andNewPasswordIsStrong() {
+    UserPutChangePasswordRequest request =
+        UserPutChangePasswordRequest.builder()
+            .currentPassword("CurrentPass#12345")
+            .newPassword("StrongPass#12345")
+            .build();
+
+    assertThat(validator.validate(request)).isEmpty();
+  }
+}

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
@@ -20,7 +20,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tools.vitruv.methodologist.messages.Error.USER_DOSE_NOT_HAVE_ACCESS;
 import static tools.vitruv.methodologist.messages.Error.USER_EMAIL_NOT_FOUND_ERROR;
+import static tools.vitruv.methodologist.messages.Error.USER_WRONG_PASSWORD_ERROR;
 
+import jakarta.ws.rs.BadRequestException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -684,11 +686,13 @@ class UserServiceTest {
         .thenReturn(Optional.of(user));
 
     UserPutChangePasswordRequest req = new UserPutChangePasswordRequest();
-    req.setPassword("StrongPass#12345");
+    req.setCurrentPassword("CurrentPass#12345");
+    req.setNewPassword("StrongPass#12345");
 
     userService.changePassword(email, req);
 
-    verify(keycloakService).setPassword(user.getUsername(), req.getPassword());
+    verify(keycloakService).verifyUserPasswordOrThrow(user.getUsername(), req.getCurrentPassword());
+    verify(keycloakService).setPassword(user.getUsername(), req.getNewPassword());
   }
 
   @Test
@@ -699,12 +703,41 @@ class UserServiceTest {
         .thenReturn(Optional.empty());
 
     UserPutChangePasswordRequest req = new UserPutChangePasswordRequest();
-    req.setPassword("StrongPass#12345");
+    req.setCurrentPassword("CurrentPass#12345");
+    req.setNewPassword("StrongPass#12345");
 
     assertThatThrownBy(() -> userService.changePassword(email, req))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining(USER_EMAIL_NOT_FOUND_ERROR);
 
+    verify(keycloakService, never()).verifyUserPasswordOrThrow(anyString(), anyString());
+    verify(keycloakService, never()).setPassword(anyString(), anyString());
+  }
+
+  @Test
+  void changePassword_throwsBadRequest_andDoesNotUpdatePassword_whenCurrentPasswordIsWrong() {
+    String email = "caller@example.com";
+
+    User user = new User();
+    user.setEmail(email);
+    user.setUsername("kc-user-1");
+
+    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull(email))
+        .thenReturn(Optional.of(user));
+
+    UserPutChangePasswordRequest req = new UserPutChangePasswordRequest();
+    req.setCurrentPassword("WrongPass#12345");
+    req.setNewPassword("StrongPass#12345");
+
+    doThrow(new BadRequestException(USER_WRONG_PASSWORD_ERROR))
+        .when(keycloakService)
+        .verifyUserPasswordOrThrow(user.getUsername(), req.getCurrentPassword());
+
+    assertThatThrownBy(() -> userService.changePassword(email, req))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining(USER_WRONG_PASSWORD_ERROR);
+
+    verify(keycloakService).verifyUserPasswordOrThrow(user.getUsername(), req.getCurrentPassword());
     verify(keycloakService, never()).setPassword(anyString(), anyString());
   }
 
@@ -720,11 +753,12 @@ class UserServiceTest {
         .thenReturn(Optional.of(user));
 
     UserPutChangePasswordRequest req = new UserPutChangePasswordRequest();
-    req.setPassword("StrongPass#12345");
+    req.setCurrentPassword("CurrentPass#12345");
+    req.setNewPassword("StrongPass#12345");
 
     doThrow(new RuntimeException("Keycloak down"))
         .when(keycloakService)
-        .setPassword(user.getUsername(), req.getPassword());
+        .setPassword(user.getUsername(), req.getNewPassword());
 
     assertThatThrownBy(() -> userService.changePassword(email, req))
         .isInstanceOf(RuntimeException.class)


### PR DESCRIPTION
## Summary
- Require `currentPassword` and `newPassword` for change-password requests.
- Verify the authenticated user’s current password before updating it in Keycloak.
- Return a clear `400 BAD_REQUEST` response when the current password is invalid.
- Redact `currentPassword` from request/response logs.