### PR TITLE
Enforce VSUM access for rule-set endpoints

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/vsum/controller/ConstraintRuleSetController.java
+++ b/app/src/main/java/tools/vitruv/methodologist/vsum/controller/ConstraintRuleSetController.java
@@ -40,13 +40,16 @@ public class ConstraintRuleSetController {
   /**
    * Returns all rule sets for the given VSUM.
    *
+   * @param authentication the current user's authentication
    * @param vsumId the VSUM ID
    * @return list of rule set responses
    */
   @GetMapping
   @PreAuthorize("isAuthenticated()")
-  public ResponseEntity<List<RuleSetResponse>> getAll(@PathVariable Long vsumId) {
-    return ResponseEntity.ok(service.findAll(vsumId));
+  public ResponseEntity<List<RuleSetResponse>> getAll(
+      KeycloakAuthentication authentication, @PathVariable Long vsumId) {
+    String email = authentication.getParsedToken().getEmail();
+    return ResponseEntity.ok(service.findAll(email, vsumId));
   }
 
   /**
@@ -90,14 +93,19 @@ public class ConstraintRuleSetController {
   /**
    * Deletes a rule set by ID.
    *
+   * @param authentication the current user's authentication
    * @param vsumId the VSUM ID
    * @param ruleSetId the rule set ID to delete
    * @return HTTP 204 No Content
    */
   @DeleteMapping("/{ruleSetId}")
   @PreAuthorize("isAuthenticated()")
-  public ResponseEntity<Void> delete(@PathVariable Long vsumId, @PathVariable Long ruleSetId) {
-    service.delete(vsumId, ruleSetId);
+  public ResponseEntity<Void> delete(
+      KeycloakAuthentication authentication,
+      @PathVariable Long vsumId,
+      @PathVariable Long ruleSetId) {
+    String email = authentication.getParsedToken().getEmail();
+    service.delete(email, vsumId, ruleSetId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/app/src/main/java/tools/vitruv/methodologist/vsum/service/ConstraintRuleSetService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/vsum/service/ConstraintRuleSetService.java
@@ -1,5 +1,7 @@
 package tools.vitruv.methodologist.vsum.service;
 
+import static tools.vitruv.methodologist.messages.Error.USER_DOSE_NOT_HAVE_ACCESS;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -9,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tools.vitruv.methodologist.exception.NotFoundException;
@@ -22,6 +25,7 @@ import tools.vitruv.methodologist.vsum.controller.dto.request.RuleSetPutRequest;
 import tools.vitruv.methodologist.vsum.controller.dto.response.RuleSetResponse;
 import tools.vitruv.methodologist.vsum.model.ConstraintRuleSet;
 import tools.vitruv.methodologist.vsum.model.Vsum;
+import tools.vitruv.methodologist.vsum.model.VsumUser;
 import tools.vitruv.methodologist.vsum.model.repository.ConstraintRuleSetRepository;
 import tools.vitruv.methodologist.vsum.model.repository.VsumRepository;
 
@@ -39,11 +43,14 @@ public class ConstraintRuleSetService {
   /**
    * Returns all rule sets for the given VSUM.
    *
+   * @param callerEmail email of the authenticated user
    * @param vsumId the VSUM ID
    * @return list of rule set responses
    */
   @Transactional(readOnly = true)
-  public List<RuleSetResponse> findAll(Long vsumId) {
+  public List<RuleSetResponse> findAll(String callerEmail, Long vsumId) {
+    User user = resolveUser(callerEmail);
+    resolveAccessibleVsum(user, vsumId);
     return ruleSetRepository.findByVsumId(vsumId).stream().map(this::toResponse).toList();
   }
 
@@ -58,7 +65,7 @@ public class ConstraintRuleSetService {
   @Transactional
   public RuleSetResponse create(String callerEmail, Long vsumId, RuleSetPostRequest request) {
     User user = resolveUser(callerEmail);
-    Vsum vsum = resolveVsum(vsumId);
+    Vsum vsum = resolveAccessibleVsum(user, vsumId);
 
     String content = request.oclContent() != null ? request.oclContent() : "";
     FileStorage oclFile = buildFileStorage(request.name(), content, user);
@@ -88,6 +95,7 @@ public class ConstraintRuleSetService {
   public RuleSetResponse update(
       String callerEmail, Long vsumId, Long ruleSetId, RuleSetPutRequest request) {
     final User user = resolveUser(callerEmail);
+    resolveAccessibleVsum(user, vsumId);
     ConstraintRuleSet ruleSet =
         ruleSetRepository
             .findByIdAndVsumId(ruleSetId, vsumId)
@@ -109,11 +117,14 @@ public class ConstraintRuleSetService {
   /**
    * Deletes a rule set by ID.
    *
+   * @param callerEmail email of the authenticated user
    * @param vsumId the VSUM ID
    * @param ruleSetId the rule set ID to delete
    */
   @Transactional
-  public void delete(Long vsumId, Long ruleSetId) {
+  public void delete(String callerEmail, Long vsumId, Long ruleSetId) {
+    User user = resolveUser(callerEmail);
+    resolveAccessibleVsum(user, vsumId);
     ConstraintRuleSet ruleSet =
         ruleSetRepository
             .findByIdAndVsumId(ruleSetId, vsumId)
@@ -172,9 +183,26 @@ public class ConstraintRuleSetService {
         .orElseThrow(UnauthorizedException::new);
   }
 
-  private Vsum resolveVsum(Long vsumId) {
-    return vsumRepository
-        .findById(vsumId)
-        .orElseThrow(() -> new NotFoundException("VSUM not found"));
+  private Vsum resolveAccessibleVsum(User user, Long vsumId) {
+    Vsum vsum =
+        vsumRepository
+            .findByIdAndRemovedAtIsNull(vsumId)
+            .orElseThrow(() -> new NotFoundException("VSUM not found"));
+    if (vsum.getVsumUsers() == null
+        || vsum.getVsumUsers().stream().noneMatch(vsumUser -> belongsToUser(vsumUser, user))) {
+      throw new AccessDeniedException(USER_DOSE_NOT_HAVE_ACCESS);
+    }
+    return vsum;
+  }
+
+  private boolean belongsToUser(VsumUser vsumUser, User user) {
+    User candidate = vsumUser.getUser();
+    if (candidate == null) {
+      return false;
+    }
+    if (user.getId() != null && candidate.getId() != null) {
+      return user.getId().equals(candidate.getId());
+    }
+    return user.getEmail() != null && user.getEmail().equalsIgnoreCase(candidate.getEmail());
   }
 }

--- a/app/src/test/java/tools/vitruv/methodologist/vsum/controller/ConstraintRuleSetControllerTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/vsum/controller/ConstraintRuleSetControllerTest.java
@@ -57,9 +57,10 @@ class ConstraintRuleSetControllerTest {
 
   @Test
   void getAll_returnsOkWithList() {
-    when(service.findAll(10L)).thenReturn(List.of(sampleResponse));
+    stubEmail();
+    when(service.findAll("test@example.com", 10L)).thenReturn(List.of(sampleResponse));
 
-    ResponseEntity<List<RuleSetResponse>> response = controller.getAll(10L);
+    ResponseEntity<List<RuleSetResponse>> response = controller.getAll(authentication, 10L);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).hasSize(1);
@@ -68,12 +69,23 @@ class ConstraintRuleSetControllerTest {
 
   @Test
   void getAll_returnsEmptyList() {
-    when(service.findAll(10L)).thenReturn(List.of());
+    stubEmail();
+    when(service.findAll("test@example.com", 10L)).thenReturn(List.of());
 
-    ResponseEntity<List<RuleSetResponse>> response = controller.getAll(10L);
+    ResponseEntity<List<RuleSetResponse>> response = controller.getAll(authentication, 10L);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(response.getBody()).isEmpty();
+  }
+
+  @Test
+  void getAll_passesEmailFromAuthentication() {
+    stubEmail();
+    when(service.findAll("test@example.com", 10L)).thenReturn(List.of(sampleResponse));
+
+    controller.getAll(authentication, 10L);
+
+    verify(service).findAll("test@example.com", 10L);
   }
 
   // ── POST /vsums/{vsumId}/rule-sets ────────────────────────────────────
@@ -159,7 +171,9 @@ class ConstraintRuleSetControllerTest {
 
   @Test
   void delete_returnsNoContent() {
-    ResponseEntity<Void> response = controller.delete(10L, 100L);
+    stubEmail();
+
+    ResponseEntity<Void> response = controller.delete(authentication, 10L, 100L);
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
     assertThat(response.getBody()).isNull();
@@ -167,16 +181,22 @@ class ConstraintRuleSetControllerTest {
 
   @Test
   void delete_callsServiceWithCorrectIds() {
-    controller.delete(10L, 100L);
+    stubEmail();
 
-    verify(service).delete(10L, 100L);
+    controller.delete(authentication, 10L, 100L);
+
+    verify(service).delete("test@example.com", 10L, 100L);
   }
 
   @Test
   void delete_propagatesNotFoundException() {
-    doThrow(new NotFoundException("RuleSet not found")).when(service).delete(10L, 999L);
+    stubEmail();
+    doThrow(new NotFoundException("RuleSet not found"))
+        .when(service)
+        .delete("test@example.com", 10L, 999L);
 
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> controller.delete(10L, 999L))
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> controller.delete(authentication, 10L, 999L))
         .isInstanceOf(NotFoundException.class);
   }
 }

--- a/app/src/test/java/tools/vitruv/methodologist/vsum/service/ConstraintRuleSetServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/vsum/service/ConstraintRuleSetServiceTest.java
@@ -6,10 +6,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tools.vitruv.methodologist.messages.Error.USER_DOSE_NOT_HAVE_ACCESS;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,16 +19,19 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
 import tools.vitruv.methodologist.exception.NotFoundException;
 import tools.vitruv.methodologist.exception.UnauthorizedException;
 import tools.vitruv.methodologist.general.model.FileStorage;
 import tools.vitruv.methodologist.user.model.User;
 import tools.vitruv.methodologist.user.model.repository.UserRepository;
+import tools.vitruv.methodologist.vsum.VsumRole;
 import tools.vitruv.methodologist.vsum.controller.dto.request.RuleSetPostRequest;
 import tools.vitruv.methodologist.vsum.controller.dto.request.RuleSetPutRequest;
 import tools.vitruv.methodologist.vsum.controller.dto.response.RuleSetResponse;
 import tools.vitruv.methodologist.vsum.model.ConstraintRuleSet;
 import tools.vitruv.methodologist.vsum.model.Vsum;
+import tools.vitruv.methodologist.vsum.model.VsumUser;
 import tools.vitruv.methodologist.vsum.model.repository.ConstraintRuleSetRepository;
 import tools.vitruv.methodologist.vsum.model.repository.VsumRepository;
 
@@ -46,6 +51,8 @@ class ConstraintRuleSetServiceTest {
   void setUp() {
     user = User.builder().id(1L).email("test@example.com").build();
     vsum = Vsum.builder().id(10L).name("TestVsum").build();
+    vsum.setVsumUsers(
+        Set.of(VsumUser.builder().vsum(vsum).user(user).role(VsumRole.OWNER).build()));
 
     FileStorage oclFile =
         FileStorage.builder()
@@ -68,9 +75,10 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void findAll_returnsMappedResponses() {
+    stubAccess(10L);
     when(ruleSetRepository.findByVsumId(10L)).thenReturn(List.of(ruleSet));
 
-    List<RuleSetResponse> result = service.findAll(10L);
+    List<RuleSetResponse> result = service.findAll("test@example.com", 10L);
 
     assertThat(result).hasSize(1);
     assertThat(result.get(0).id()).isEqualTo(100L);
@@ -82,26 +90,29 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void findAll_emptyList_whenNoRuleSets() {
+    stubAccess(99L);
     when(ruleSetRepository.findByVsumId(99L)).thenReturn(List.of());
 
-    List<RuleSetResponse> result = service.findAll(99L);
+    List<RuleSetResponse> result = service.findAll("test@example.com", 99L);
 
     assertThat(result).isEmpty();
   }
 
   @Test
   void findAll_handlesNullOclFile() {
+    stubAccess(10L);
     ConstraintRuleSet noFile =
         ConstraintRuleSet.builder().id(200L).vsum(vsum).name("Empty").color("#fff").build();
     when(ruleSetRepository.findByVsumId(10L)).thenReturn(List.of(noFile));
 
-    List<RuleSetResponse> result = service.findAll(10L);
+    List<RuleSetResponse> result = service.findAll("test@example.com", 10L);
 
     assertThat(result.get(0).oclContent()).isEmpty();
   }
 
   @Test
   void findAll_handlesNullOclFileData() {
+    stubAccess(10L);
     FileStorage emptyFile = FileStorage.builder().filename("x.ocl").data(null).build();
     ConstraintRuleSet rs =
         ConstraintRuleSet.builder()
@@ -113,18 +124,30 @@ class ConstraintRuleSetServiceTest {
             .build();
     when(ruleSetRepository.findByVsumId(10L)).thenReturn(List.of(rs));
 
-    List<RuleSetResponse> result = service.findAll(10L);
+    List<RuleSetResponse> result = service.findAll("test@example.com", 10L);
 
     assertThat(result.get(0).oclContent()).isEmpty();
+  }
+
+  @Test
+  void findAll_throwsAccessDenied_whenCallerHasNoVsumAccess() {
+    Vsum inaccessible = Vsum.builder().id(10L).name("TestVsum").vsumUsers(Set.of()).build();
+    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
+        .thenReturn(Optional.of(user));
+    when(vsumRepository.findByIdAndRemovedAtIsNull(10L)).thenReturn(Optional.of(inaccessible));
+
+    assertThatThrownBy(() -> service.findAll("test@example.com", 10L))
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessageContaining(USER_DOSE_NOT_HAVE_ACCESS);
+
+    verify(ruleSetRepository, never()).findByVsumId(10L);
   }
 
   // ── create ───────────────────────────────────────────────────────────────
 
   @Test
   void create_savesAndReturnsResponse() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
-    when(vsumRepository.findById(10L)).thenReturn(Optional.of(vsum));
+    stubAccess(10L);
     when(ruleSetRepository.save(any()))
         .thenAnswer(
             inv -> {
@@ -156,9 +179,7 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void create_usesDefaultColorWhenNull() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
-    when(vsumRepository.findById(10L)).thenReturn(Optional.of(vsum));
+    stubAccess(10L);
 
     ArgumentCaptor<ConstraintRuleSet> captor = ArgumentCaptor.forClass(ConstraintRuleSet.class);
     when(ruleSetRepository.save(captor.capture()))
@@ -182,9 +203,7 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void create_usesEmptyContentWhenOclContentNull() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
-    when(vsumRepository.findById(10L)).thenReturn(Optional.of(vsum));
+    stubAccess(10L);
 
     ArgumentCaptor<ConstraintRuleSet> captor = ArgumentCaptor.forClass(ConstraintRuleSet.class);
     when(ruleSetRepository.save(captor.capture()))
@@ -220,7 +239,7 @@ class ConstraintRuleSetServiceTest {
   void create_throwsNotFound_whenVsumNotFound() {
     when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
         .thenReturn(Optional.of(user));
-    when(vsumRepository.findById(99L)).thenReturn(Optional.empty());
+    when(vsumRepository.findByIdAndRemovedAtIsNull(99L)).thenReturn(Optional.empty());
 
     var req = new RuleSetPostRequest("X", null, null, null);
     assertThatThrownBy(() -> service.create("test@example.com", 99L, req))
@@ -229,10 +248,23 @@ class ConstraintRuleSetServiceTest {
   }
 
   @Test
-  void create_oclFileHasCorrectFilename() {
+  void create_throwsAccessDenied_whenCallerHasNoVsumAccess() {
+    Vsum inaccessible = Vsum.builder().id(10L).name("TestVsum").vsumUsers(Set.of()).build();
     when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
         .thenReturn(Optional.of(user));
-    when(vsumRepository.findById(10L)).thenReturn(Optional.of(vsum));
+    when(vsumRepository.findByIdAndRemovedAtIsNull(10L)).thenReturn(Optional.of(inaccessible));
+
+    var req = new RuleSetPostRequest("X", null, null, null);
+    assertThatThrownBy(() -> service.create("test@example.com", 10L, req))
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessageContaining(USER_DOSE_NOT_HAVE_ACCESS);
+
+    verify(ruleSetRepository, never()).save(any());
+  }
+
+  @Test
+  void create_oclFileHasCorrectFilename() {
+    stubAccess(10L);
 
     ArgumentCaptor<ConstraintRuleSet> captor = ArgumentCaptor.forClass(ConstraintRuleSet.class);
     when(ruleSetRepository.save(captor.capture()))
@@ -256,9 +288,7 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void create_oclFileHasSha256() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
-    when(vsumRepository.findById(10L)).thenReturn(Optional.of(vsum));
+    stubAccess(10L);
 
     ArgumentCaptor<ConstraintRuleSet> captor = ArgumentCaptor.forClass(ConstraintRuleSet.class);
     when(ruleSetRepository.save(captor.capture()))
@@ -283,8 +313,7 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void update_updatesFieldsAndReturnsResponse() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(100L, 10L)).thenReturn(Optional.of(ruleSet));
     when(ruleSetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -301,8 +330,7 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void update_keepsOldColor_whenRequestColorNull() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(100L, 10L)).thenReturn(Optional.of(ruleSet));
     when(ruleSetRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -315,8 +343,7 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void update_throwsNotFound_whenRuleSetNotFound() {
-    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
-        .thenReturn(Optional.of(user));
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(999L, 10L)).thenReturn(Optional.empty());
 
     var req = new RuleSetPutRequest("X", null, null, null);
@@ -336,9 +363,24 @@ class ConstraintRuleSetServiceTest {
   }
 
   @Test
-  void update_usesEmptyContentWhenOclContentNull() {
+  void update_throwsAccessDenied_whenCallerHasNoVsumAccess() {
+    Vsum inaccessible = Vsum.builder().id(10L).name("TestVsum").vsumUsers(Set.of()).build();
     when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
         .thenReturn(Optional.of(user));
+    when(vsumRepository.findByIdAndRemovedAtIsNull(10L)).thenReturn(Optional.of(inaccessible));
+
+    var req = new RuleSetPutRequest("X", null, null, null);
+    assertThatThrownBy(() -> service.update("test@example.com", 10L, 100L, req))
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessageContaining(USER_DOSE_NOT_HAVE_ACCESS);
+
+    verify(ruleSetRepository, never()).findByIdAndVsumId(100L, 10L);
+    verify(ruleSetRepository, never()).save(any());
+  }
+
+  @Test
+  void update_usesEmptyContentWhenOclContentNull() {
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(100L, 10L)).thenReturn(Optional.of(ruleSet));
 
     ArgumentCaptor<ConstraintRuleSet> captor = ArgumentCaptor.forClass(ConstraintRuleSet.class);
@@ -354,29 +396,53 @@ class ConstraintRuleSetServiceTest {
 
   @Test
   void delete_removesRuleSet() {
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(100L, 10L)).thenReturn(Optional.of(ruleSet));
 
-    service.delete(10L, 100L);
+    service.delete("test@example.com", 10L, 100L);
 
     verify(ruleSetRepository).delete(ruleSet);
   }
 
   @Test
   void delete_throwsNotFound_whenRuleSetNotFound() {
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(999L, 10L)).thenReturn(Optional.empty());
 
-    assertThatThrownBy(() -> service.delete(10L, 999L))
+    assertThatThrownBy(() -> service.delete("test@example.com", 10L, 999L))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("RuleSet not found");
   }
 
   @Test
+  void delete_throwsAccessDenied_whenCallerHasNoVsumAccess() {
+    Vsum inaccessible = Vsum.builder().id(10L).name("TestVsum").vsumUsers(Set.of()).build();
+    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
+        .thenReturn(Optional.of(user));
+    when(vsumRepository.findByIdAndRemovedAtIsNull(10L)).thenReturn(Optional.of(inaccessible));
+
+    assertThatThrownBy(() -> service.delete("test@example.com", 10L, 100L))
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessageContaining(USER_DOSE_NOT_HAVE_ACCESS);
+
+    verify(ruleSetRepository, never()).findByIdAndVsumId(100L, 10L);
+    verify(ruleSetRepository, never()).delete(any());
+  }
+
+  @Test
   void delete_doesNotDeleteOtherRuleSets() {
     ConstraintRuleSet otherRuleSet = new ConstraintRuleSet();
+    stubAccess(10L);
     when(ruleSetRepository.findByIdAndVsumId(100L, 10L)).thenReturn(Optional.of(ruleSet));
 
-    service.delete(10L, 100L);
+    service.delete("test@example.com", 10L, 100L);
 
     verify(ruleSetRepository, never()).delete(otherRuleSet);
+  }
+
+  private void stubAccess(Long vsumId) {
+    when(userRepository.findByEmailIgnoreCaseAndRemovedAtIsNull("test@example.com"))
+        .thenReturn(Optional.of(user));
+    when(vsumRepository.findByIdAndRemovedAtIsNull(vsumId)).thenReturn(Optional.of(vsum));
   }
 }


### PR DESCRIPTION
## Summary
- Pass authenticated user context into VSUM rule-set list and delete endpoints.
- Enforce VSUM membership before listing, creating, updating, or deleting rule sets.
- Return 403 for existing VSUMs when the caller is not a member, while missing VSUMs still return 404.
- Add controller and service tests for authorized and denied rule-set access.