### PR TITLE
Specify transaction behavior for metamodel IO failures

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/vsum/service/MetaModelService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/vsum/service/MetaModelService.java
@@ -433,7 +433,7 @@ public class MetaModelService {
    * @param vsumId project/VSUM whose metamodels should be included
    * @throws IOException if file writing fails
    */
-  @Transactional(readOnly = true)
+  @Transactional(readOnly = true, noRollbackFor = IOException.class)
   public void writeMetamodelsToDirectory(File targetDir, Long vsumId) throws IOException {
     List<MetaModel> metamodels = self.findAccessibleByProject(vsumId);
 


### PR DESCRIPTION
## Summary
- Specify checked-exception transaction behavior for `writeMetamodelsToDirectory`.
- Mark `IOException` as `noRollbackFor` because the method is read-only and failures are file-system related.
