### PR TITLE
Fix profile name update

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGateway.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGateway.java
@@ -40,6 +40,15 @@ public interface KeycloakGateway {
   void removeUser(String userId);
 
   /**
+   * Updates a user's editable profile names by Keycloak user ID.
+   *
+   * @param userId the Keycloak user ID
+   * @param firstName the first name to persist
+   * @param lastName the last name to persist
+   */
+  void updateUserProfile(String userId, String firstName, String lastName);
+
+  /**
    * Verifies a username and password against Keycloak.
    *
    * @param username the username to verify

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImpl.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImpl.java
@@ -110,6 +110,15 @@ public class KeycloakGatewayImpl implements KeycloakGateway {
   }
 
   @Override
+  public void updateUserProfile(String userId, String firstName, String lastName) {
+    final var userResource = keycloakAdmin.realm(realm).users().get(userId);
+    final UserRepresentation userRepresentation = userResource.toRepresentation();
+    userRepresentation.setFirstName(firstName);
+    userRepresentation.setLastName(lastName);
+    userResource.update(userRepresentation);
+  }
+
+  @Override
   public void verifyPassword(String username, String password) {
     requestAccessToken(authServerUrl, realm, clientId, username, password);
   }

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakService.java
@@ -144,6 +144,19 @@ public class KeycloakService {
   }
 
   /**
+   * Updates a user's editable profile names in Keycloak.
+   *
+   * @param username the username of the user to update
+   * @param firstName the first name to persist
+   * @param lastName the last name to persist
+   */
+  @Transactional
+  public void updateUserProfile(String username, String firstName, String lastName) {
+    final UserRepresentation userRepresentation = getUserRepresentationOrThrow(username);
+    keycloakGateway.updateUserProfile(userRepresentation.getId(), firstName, lastName);
+  }
+
+  /**
    * Verifies a user's password against Keycloak.
    *
    * @param username the username

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
@@ -241,9 +241,9 @@ public class UserService {
   /**
    * Synchronizes a user account with Keycloak, creating or updating the user as needed.
    *
-   * <p>Searches for an existing, non-removed user by username. If found, updates the user's email,
-   * first name, and last name with the provided values. If not found, creates a new user with the
-   * provided credentials, marking them as verified by default with the USER role.
+   * <p>Searches for an existing, non-removed user by username. If found, updates the user's email.
+   * If not found, creates a new user with the provided credentials, marking them as verified by
+   * default with the USER role.
    *
    * <p>After the user is persisted, the Keycloak user role is assigned or updated for the given
    * username to synchronize role information across systems.
@@ -269,7 +269,7 @@ public class UserService {
 
     User userToSave =
         existingUser
-            .map(user -> updateExistingUser(user, email, firstName, lastName))
+            .map(user -> updateExistingUser(user, email))
             .orElseGet(() -> createNewUser(email, username, firstName, lastName));
 
     userRepository.save(userToSave);
@@ -306,18 +306,14 @@ public class UserService {
   }
 
   /**
-   * Updates an existing user with the provided information.
+   * Updates an existing user with Keycloak-owned identity information.
    *
    * @param user the existing user to update
    * @param email the new email address
-   * @param firstName the new first name
-   * @param lastName the new last name
    * @return the updated user entity
    */
-  private User updateExistingUser(User user, String email, String firstName, String lastName) {
+  private User updateExistingUser(User user, String email) {
     user.setEmail(email);
-    user.setFirstName(firstName);
-    user.setLastName(lastName);
     return user;
   }
 
@@ -392,6 +388,7 @@ public class UserService {
             .findByIdAndRemovedAtIsNull(id)
             .orElseThrow(() -> new NotFoundException(USER_ID_NOT_FOUND_ERROR));
     userMapper.updateByUserPutRequest(userPutRequest, user);
+    keycloakService.updateUserProfile(user.getUsername(), user.getFirstName(), user.getLastName());
     userRepository.save(user);
     return user;
   }

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImplTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImplTest.java
@@ -157,6 +157,40 @@ class KeycloakGatewayImplTest {
   }
 
   @Test
+  void updateUserProfile_updatesKeycloakUser() throws Exception {
+    try (KeycloakServerFixture fixture = new KeycloakServerFixture()) {
+      fixture.enqueueTokenResponse();
+      fixture.enqueueJson(
+          """
+          {
+            "id": "user-1",
+            "username": "alice",
+            "email": "alice@example.com",
+            "firstName": "Alice",
+            "lastName": "Doe",
+            "enabled": true
+          }
+          """);
+      fixture.enqueue(new MockResponse().setResponseCode(204));
+
+      fixture.gateway.updateUserProfile("user-1", "Alicia", "Smith");
+
+      fixture.assertAdminTokenRequest(fixture.takeRequest());
+      final RecordedRequest getRequest = fixture.takeRequest();
+      assertThat(getRequest.getMethod()).isEqualTo("GET");
+      assertThat(getRequest.getPath()).isEqualTo("/admin/realms/methodologist/users/user-1");
+      final RecordedRequest updateRequest = fixture.takeRequest();
+      assertThat(updateRequest.getMethod()).isEqualTo("PUT");
+      assertThat(updateRequest.getPath()).isEqualTo("/admin/realms/methodologist/users/user-1");
+      assertThat(updateRequest.getBody().readUtf8())
+          .contains("\"username\":\"alice\"")
+          .contains("\"email\":\"alice@example.com\"")
+          .contains("\"firstName\":\"Alicia\"")
+          .contains("\"lastName\":\"Smith\"");
+    }
+  }
+
+  @Test
   void verifyPassword_requestsTokenFromConfiguredKeycloakServer() throws Exception {
     try (KeycloakServerFixture fixture = new KeycloakServerFixture()) {
       fixture.enqueueTokenResponse();

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/KeycloakServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/KeycloakServiceTest.java
@@ -112,6 +112,25 @@ class KeycloakServiceTest {
   }
 
   @Test
+  void updateUserProfile_updatesNames_whenUserExists() {
+    keycloakGateway.addUser("alice", "user-1");
+
+    keycloakService.updateUserProfile("alice", "Alicia", "Smith");
+
+    assertThat(keycloakGateway.updatedUserId).isEqualTo("user-1");
+    assertThat(keycloakGateway.updatedFirstName).isEqualTo("Alicia");
+    assertThat(keycloakGateway.updatedLastName).isEqualTo("Smith");
+  }
+
+  @Test
+  void updateUserProfile_throwsNotFound_whenUserDoesNotExist() {
+    assertThatThrownBy(() -> keycloakService.updateUserProfile("missing", "Alicia", "Smith"))
+        .isInstanceOf(NotFoundException.class);
+
+    assertThat(keycloakGateway.updatedUserId).isNull();
+  }
+
+  @Test
   void verifyUserPasswordOrThrow_doesNotThrow_whenPasswordIsValid() {
     keycloakService.verifyUserPasswordOrThrow("alice", "correct-password");
 
@@ -247,6 +266,9 @@ class KeycloakServiceTest {
     private RuntimeException assignRoleException;
     private RuntimeException verifyPasswordException;
     private UserRepresentation createdUserRepresentation;
+    private String updatedUserId;
+    private String updatedFirstName;
+    private String updatedLastName;
     private String assignedRoleUserId;
     private String assignedRole;
     private String verifiedUsername;
@@ -284,6 +306,13 @@ class KeycloakServiceTest {
       usersByUsername
           .values()
           .removeIf(userRepresentation -> userId.equals(userRepresentation.getId()));
+    }
+
+    @Override
+    public void updateUserProfile(String userId, String firstName, String lastName) {
+      updatedUserId = userId;
+      updatedFirstName = firstName;
+      updatedLastName = lastName;
     }
 
     @Override

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -231,16 +232,57 @@ class UserServiceTest {
     User existing = new User();
     existing.setId(id);
     existing.setEmail("alice@example.com");
+    existing.setUsername("alice");
 
     UserPutRequest put = UserPutRequest.builder().firstName("Alicia").lastName("Doe").build();
 
     when(userRepository.findByIdAndRemovedAtIsNull(id)).thenReturn(Optional.of(existing));
+    doAnswer(
+            invocation -> {
+              User user = invocation.getArgument(1);
+              user.setFirstName(put.getFirstName());
+              user.setLastName(put.getLastName());
+              return null;
+            })
+        .when(userMapper)
+        .updateByUserPutRequest(put, existing);
 
     User result = userService.update(id, put);
 
     assertThat(result).isSameAs(existing);
     verify(userMapper).updateByUserPutRequest(eq(put), eq(existing));
+    verify(keycloakService).updateUserProfile("alice", "Alicia", "Doe");
     verify(userRepository).save(existing);
+  }
+
+  @Test
+  void update_propagatesKeycloakError_andDoesNotSave() {
+    long id = 42L;
+    User existing = new User();
+    existing.setId(id);
+    existing.setEmail("alice@example.com");
+    existing.setUsername("alice");
+    UserPutRequest put = UserPutRequest.builder().firstName("Alicia").lastName("Doe").build();
+
+    when(userRepository.findByIdAndRemovedAtIsNull(id)).thenReturn(Optional.of(existing));
+    doAnswer(
+            invocation -> {
+              User user = invocation.getArgument(1);
+              user.setFirstName(put.getFirstName());
+              user.setLastName(put.getLastName());
+              return null;
+            })
+        .when(userMapper)
+        .updateByUserPutRequest(put, existing);
+    doThrow(new RuntimeException("Keycloak service down"))
+        .when(keycloakService)
+        .updateUserProfile("alice", "Alicia", "Doe");
+
+    assertThatThrownBy(() -> userService.update(id, put))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("Keycloak service down");
+
+    verify(userRepository, never()).save(any());
   }
 
   @Test
@@ -758,7 +800,7 @@ class UserServiceTest {
   }
 
   @Test
-  void syncWithKeycloak_updatesExistingUser_whenUsernameFound() {
+  void syncWithKeycloak_preservesExistingNames_whenUsernameFound() {
     User existingUser = new User();
     existingUser.setId(1L);
     existingUser.setEmail("oldemail@example.com");
@@ -773,9 +815,7 @@ class UserServiceTest {
         .thenReturn(Optional.of(existingUser));
 
     String newEmail = "updatedemail@example.com";
-    String newFirstName = "Jane";
-    String newLastName = "Smith";
-    userService.syncWithKeycloak(newEmail, username, newFirstName, newLastName);
+    userService.syncWithKeycloak(newEmail, username, "Jane", "Smith");
 
     ArgumentCaptor<User> savedCaptor = ArgumentCaptor.forClass(User.class);
     verify(userRepository).save(savedCaptor.capture());
@@ -784,8 +824,8 @@ class UserServiceTest {
     assertThat(savedUser.getId()).isEqualTo(1L);
     assertThat(savedUser.getEmail()).isEqualTo(newEmail);
     assertThat(savedUser.getUsername()).isEqualTo(username);
-    assertThat(savedUser.getFirstName()).isEqualTo(newFirstName);
-    assertThat(savedUser.getLastName()).isEqualTo(newLastName);
+    assertThat(savedUser.getFirstName()).isEqualTo("Old");
+    assertThat(savedUser.getLastName()).isEqualTo("Name");
     assertThat(savedUser.getVerified()).isTrue();
 
     verify(keycloakService).assignUserRole(username, RoleType.USER.getName());
@@ -814,6 +854,8 @@ class UserServiceTest {
     User saved = savedCaptor.getValue();
     assertThat(saved.getId()).isEqualTo(99L);
     assertThat(saved.getVerified()).isTrue();
+    assertThat(saved.getFirstName()).isEqualTo("Old");
+    assertThat(saved.getLastName()).isEqualTo("Value");
   }
 
   @Test


### PR DESCRIPTION
Changes:
- Syncs updated first/last name to Keycloak when profile is updated.
- Stops `syncWithKeycloak` from overwriting existing DB names with stale JWT claims.
- Adds tests for profile update, Keycloak sync, and stale-name preservation.
