### PR TITLE
Avoid blocking thread for workspace ready

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/config/OclLspWebSocketHandler.java
+++ b/app/src/main/java/tools/vitruv/methodologist/config/OclLspWebSocketHandler.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -176,22 +177,19 @@ public class OclLspWebSocketHandler extends TextWebSocketHandler {
     new Thread(lspProcess::readFromLsp).start();
 
     // Notify client that workspace is ready
-    new Thread(
+    CompletableFuture.delayedExecutor(500, TimeUnit.MILLISECONDS)
+        .execute(
             () -> {
               try {
-                Thread.sleep(500);
                 String rootUriMessage =
                     String.format(
                         "{\"type\":\"workspaceReady\",\"rootUri\":\"%s\"}",
                         userProject.toUri().toString());
                 session.sendMessage(new TextMessage(rootUriMessage));
-              } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
               } catch (Exception e) {
                 logger.error("💥 Failed to send workspaceReady for OCL-LSP: {}", e.getMessage());
               }
-            })
-        .start();
+            });
   }
 
   @Override


### PR DESCRIPTION
Changes:
- Replaced the dedicated sleeping thread with `CompletableFuture.delayedExecutor(...)`.
- Kept the notification delay behavior unchanged.
