### PR TITLE
Fix Keycloak Null Safety

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/config/KeycloakAuthentication.java
+++ b/app/src/main/java/tools/vitruv/methodologist/config/KeycloakAuthentication.java
@@ -8,7 +8,9 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -48,8 +50,23 @@ public class KeycloakAuthentication extends JwtAuthenticationToken implements Se
    * @param authorities the granted authorities for the authenticated user
    */
   public KeycloakAuthentication(Jwt jwt, Collection<? extends GrantedAuthority> authorities) {
-    super(jwt, authorities);
-    this.parsedToken = MAPPER.convertValue(jwt.getClaims(), ParsedToken.class);
+    super(Objects.requireNonNull(jwt, "jwt must not be null"), emptyIfNull(authorities));
+    this.parsedToken = MAPPER.convertValue(getToken().getClaims(), ParsedToken.class);
+  }
+
+  private static Collection<? extends GrantedAuthority> emptyIfNull(
+      Collection<? extends GrantedAuthority> authorities) {
+    return authorities == null ? Collections.emptyList() : authorities;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    return super.equals(object);
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
   }
 
   /** Strongly-typed representation of JWT claims. */

--- a/app/src/main/java/tools/vitruv/methodologist/config/KeycloakJwtAuthenticationConverter.java
+++ b/app/src/main/java/tools/vitruv/methodologist/config/KeycloakJwtAuthenticationConverter.java
@@ -1,6 +1,8 @@
 package tools.vitruv.methodologist.config;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -28,7 +30,10 @@ public class KeycloakJwtAuthenticationConverter
    */
   @Override
   public AbstractAuthenticationToken convert(Jwt jwt) {
-    Collection<? extends GrantedAuthority> authorities = authoritiesConverter.convert(jwt);
-    return new KeycloakAuthentication(jwt, authorities);
+    Jwt requiredJwt = Objects.requireNonNull(jwt, "jwt must not be null");
+    Collection<? extends GrantedAuthority> authorities =
+        Objects.requireNonNullElse(
+            authoritiesConverter.convert(requiredJwt), Collections.emptyList());
+    return new KeycloakAuthentication(requiredJwt, authorities);
   }
 }


### PR DESCRIPTION
**Summary**
- Added null-safety for Keycloak JWT conversion.
- Ensured authorities default to an empty list when missing.
- Added explicit `equals` / `hashCode` overrides for `KeycloakAuthentication`.