### PR TITLE
Fix current password validation when changing passwords

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequest.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequest.java
@@ -1,5 +1,6 @@
 package tools.vitruv.methodologist.user.controller.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -31,6 +32,7 @@ public class UserPutChangePasswordRequest {
 
   @NotNull
   @NotBlank
+  @JsonAlias("password")
   @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
   @Pattern(
       regexp = "^(?=.{8,256}$)(?=.*\\p{Ll})(?=.*\\p{Lu})(?=.*\\p{Nd})(?=.*[^\\p{L}\\p{Nd}\\s]).*$",

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImpl.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImpl.java
@@ -38,7 +38,9 @@ public class KeycloakGatewayImpl implements KeycloakGateway {
       @Value("${keycloak.admin.username}") String adminUsername,
       @Value("${keycloak.admin.password}") String adminPassword,
       @Value("${keycloak.admin.client-secret}") String secret,
-      @Value("${spring.security.oauth2.client.registration.keycloak.client-id}") String clientId) {
+      @Value(
+              "${methodologist.keycloak.client-id:${spring.security.oauth2.client.registration.keycloak.client-id}}")
+          String clientId) {
     this.authServerUrl = authServerUrl;
     this.realm = realm;
     this.clientId = clientId;

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImpl.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakGatewayImpl.java
@@ -39,7 +39,8 @@ public class KeycloakGatewayImpl implements KeycloakGateway {
       @Value("${keycloak.admin.password}") String adminPassword,
       @Value("${keycloak.admin.client-secret}") String secret,
       @Value(
-              "${methodologist.keycloak.client-id:${spring.security.oauth2.client.registration.keycloak.client-id}}")
+              "${methodologist.keycloak.client-id:"
+                  + "${spring.security.oauth2.client.registration.keycloak.client-id}}")
           String clientId) {
     this.authServerUrl = authServerUrl;
     this.realm = realm;

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/KeycloakService.java
@@ -169,7 +169,7 @@ public class KeycloakService {
   public void verifyUserPasswordOrThrow(String username, String password) {
     try {
       keycloakGateway.verifyPassword(username, password);
-    } catch (NotAuthorizedException notAuthorizedException) {
+    } catch (NotAuthorizedException | BadRequestException wrongPasswordException) {
       throw new BadRequestException(USER_WRONG_PASSWORD_ERROR);
     } catch (Exception e) {
       throw new UncheckedRuntimeException(e.getMessage());

--- a/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
+++ b/app/src/main/java/tools/vitruv/methodologist/user/service/UserService.java
@@ -3,7 +3,9 @@ package tools.vitruv.methodologist.user.service;
 import static tools.vitruv.methodologist.messages.Error.USER_DOSE_NOT_HAVE_ACCESS;
 import static tools.vitruv.methodologist.messages.Error.USER_EMAIL_NOT_FOUND_ERROR;
 import static tools.vitruv.methodologist.messages.Error.USER_ID_NOT_FOUND_ERROR;
+import static tools.vitruv.methodologist.messages.Error.USER_WRONG_PASSWORD_ERROR;
 
+import jakarta.ws.rs.BadRequestException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -459,8 +461,12 @@ public class UserService {
         userRepository
             .findByEmailIgnoreCaseAndRemovedAtIsNull(email)
             .orElseThrow(() -> new NotFoundException(USER_EMAIL_NOT_FOUND_ERROR));
-    keycloakService.verifyUserPasswordOrThrow(
-        user.getUsername(), userPutChangePasswordRequest.getCurrentPassword());
+    try {
+      keycloakApiHandler.getAccessTokenOrThrow(
+          user.getUsername(), userPutChangePasswordRequest.getCurrentPassword());
+    } catch (Exception exception) {
+      throw new BadRequestException(USER_WRONG_PASSWORD_ERROR);
+    }
     keycloakService.setPassword(user.getUsername(), userPutChangePasswordRequest.getNewPassword());
   }
 

--- a/app/src/test/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequestTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/controller/dto/request/UserPutChangePasswordRequestTest.java
@@ -2,6 +2,7 @@ package tools.vitruv.methodologist.user.controller.dto.request;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
@@ -63,5 +64,22 @@ class UserPutChangePasswordRequestTest {
             .build();
 
     assertThat(validator.validate(request)).isEmpty();
+  }
+
+  @Test
+  void deserialize_mapsLegacyPasswordFieldToNewPassword() throws Exception {
+    UserPutChangePasswordRequest request =
+        new ObjectMapper()
+            .readValue(
+                """
+                {
+                  "currentPassword": "CurrentPass#12345",
+                  "password": "StrongPass#12345"
+                }
+                """,
+                UserPutChangePasswordRequest.class);
+
+    assertThat(request.getCurrentPassword()).isEqualTo("CurrentPass#12345");
+    assertThat(request.getNewPassword()).isEqualTo("StrongPass#12345");
   }
 }

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/KeycloakServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/KeycloakServiceTest.java
@@ -148,6 +148,15 @@ class KeycloakServiceTest {
   }
 
   @Test
+  void verifyUserPasswordOrThrow_throwsBadRequest_whenKeycloakReturnsInvalidGrant() {
+    keycloakGateway.verifyPasswordException = new BadRequestException("invalid_grant");
+
+    assertThatThrownBy(() -> keycloakService.verifyUserPasswordOrThrow("alice", "wrong-password"))
+        .isInstanceOf(BadRequestException.class)
+        .hasMessageContaining(USER_WRONG_PASSWORD_ERROR);
+  }
+
+  @Test
   void verifyUserPasswordOrThrow_throwsUncheckedRuntime_whenKeycloakFailsUnexpectedly() {
     keycloakGateway.verifyPasswordException = new RuntimeException("server error");
 

--- a/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/user/service/UserServiceTest.java
@@ -731,9 +731,12 @@ class UserServiceTest {
     req.setCurrentPassword("CurrentPass#12345");
     req.setNewPassword("StrongPass#12345");
 
+    when(keycloakApiHandler.getAccessTokenOrThrow(user.getUsername(), req.getCurrentPassword()))
+        .thenReturn(new KeycloakWebToken());
+
     userService.changePassword(email, req);
 
-    verify(keycloakService).verifyUserPasswordOrThrow(user.getUsername(), req.getCurrentPassword());
+    verify(keycloakApiHandler).getAccessTokenOrThrow(user.getUsername(), req.getCurrentPassword());
     verify(keycloakService).setPassword(user.getUsername(), req.getNewPassword());
   }
 
@@ -752,7 +755,7 @@ class UserServiceTest {
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining(USER_EMAIL_NOT_FOUND_ERROR);
 
-    verify(keycloakService, never()).verifyUserPasswordOrThrow(anyString(), anyString());
+    verify(keycloakApiHandler, never()).getAccessTokenOrThrow(anyString(), anyString());
     verify(keycloakService, never()).setPassword(anyString(), anyString());
   }
 
@@ -771,15 +774,15 @@ class UserServiceTest {
     req.setCurrentPassword("WrongPass#12345");
     req.setNewPassword("StrongPass#12345");
 
-    doThrow(new BadRequestException(USER_WRONG_PASSWORD_ERROR))
-        .when(keycloakService)
-        .verifyUserPasswordOrThrow(user.getUsername(), req.getCurrentPassword());
+    doThrow(new RuntimeException("invalid credentials"))
+        .when(keycloakApiHandler)
+        .getAccessTokenOrThrow(user.getUsername(), req.getCurrentPassword());
 
     assertThatThrownBy(() -> userService.changePassword(email, req))
         .isInstanceOf(BadRequestException.class)
         .hasMessageContaining(USER_WRONG_PASSWORD_ERROR);
 
-    verify(keycloakService).verifyUserPasswordOrThrow(user.getUsername(), req.getCurrentPassword());
+    verify(keycloakApiHandler).getAccessTokenOrThrow(user.getUsername(), req.getCurrentPassword());
     verify(keycloakService, never()).setPassword(anyString(), anyString());
   }
 


### PR DESCRIPTION
## Changes

- Require validation of the user’s current password before changing it.
- Verify credentials through Keycloak’s token endpoint.
- Prevent `setPassword` from running when verification fails.
- Return `400 Bad Request` with `Wrong password`.
- Support the frontend payload using `password` as the new-password field.
- Add unit and real Keycloak integration coverage.