### PR TITLE
Extract setup-service request constant

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/apihandler/SetupServiceApiHandler.java
+++ b/app/src/main/java/tools/vitruv/methodologist/apihandler/SetupServiceApiHandler.java
@@ -38,6 +38,7 @@ public class SetupServiceApiHandler {
   public static final String REACTION_FILES_PART = "reactionFiles";
   public static final String FILE_PART = "file";
 
+  private static final String SETUP_SERVICE_REQUEST_TO = "Setup-service request to '";
   private static final MediaType APPLICATION_ZIP = MediaType.parseMediaType("application/zip");
   private static final MediaType APPLICATION_JAR =
       MediaType.parseMediaType("application/java-archive");
@@ -145,7 +146,7 @@ public class SetupServiceApiHandler {
                               body ->
                                   Mono.error(
                                       new SetupServiceException(
-                                          "Setup-service request to '"
+                                          SETUP_SERVICE_REQUEST_TO
                                               + uri
                                               + "' failed with status "
                                               + response.statusCode()
@@ -199,7 +200,7 @@ public class SetupServiceApiHandler {
                               body ->
                                   Mono.error(
                                       new SetupServiceException(
-                                          "Setup-service request to '"
+                                          SETUP_SERVICE_REQUEST_TO
                                               + PROCESS_GENMODEL_URL
                                               + "' failed with status "
                                               + response.statusCode()
@@ -260,7 +261,7 @@ public class SetupServiceApiHandler {
                             body ->
                                 Mono.error(
                                     new SetupServiceException(
-                                        "Setup-service request to '"
+                                        SETUP_SERVICE_REQUEST_TO
                                             + INSPECT_GENMODEL_URL
                                             + "' failed with status "
                                             + response.statusCode()


### PR DESCRIPTION
## Summary

- Extracted the duplicated `"Setup-service request to '"` literal into a constant.
- Reused it across all three error messages.
- Resolves Sonar rule `java:S1192`.