### PR TITLE
Mark inspection response data as transient

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/apihandler/dto/response/GenModelInspectionResponse.java
+++ b/app/src/main/java/tools/vitruv/methodologist/apihandler/dto/response/GenModelInspectionResponse.java
@@ -27,5 +27,5 @@ public class GenModelInspectionResponse implements Serializable {
   private String path;
   private Integer status;
   private Long timestamp;
-  private List<Object> data;
+  private transient List<Object> data;
 }


### PR DESCRIPTION
## Summary

- Marked `GenModelInspectionResponse.data` as `transient`.
- Resolves Sonar rule `java:S1948`.
- Prevents the potentially non-serializable `List<Object>` from participating in Java serialization.