### PR TITLE
Simplify invitation exception assertion

### DIFF
--- a/app/src/test/java/tools/vitruv/methodologist/vsum/service/VsumInvitationServiceTest.java
+++ b/app/src/test/java/tools/vitruv/methodologist/vsum/service/VsumInvitationServiceTest.java
@@ -270,8 +270,9 @@ class VsumInvitationServiceTest {
     when(vsumInvitationRepository.existsByVsumAndInviteeEmailIgnoreCaseAndStatus(
             vsum, INVITEE_EMAIL, VsumInvitationStatus.PENDING))
         .thenReturn(true);
+    VsumInvitationPostRequest invitationRequest = request(INVITEE_EMAIL);
 
-    assertThatThrownBy(() -> service.invite(OWNER_EMAIL, request(INVITEE_EMAIL)))
+    assertThatThrownBy(() -> service.invite(OWNER_EMAIL, invitationRequest))
         .isInstanceOf(VsumInvitationAlreadyExistsException.class);
 
     verify(vsumInvitationRepository, never()).save(any());


### PR DESCRIPTION
## Summary

- Created the invitation request before the exception assertion.
- Reduced the `assertThatThrownBy` lambda to a single potentially throwing invocation.
- Resolves Sonar rule `java:S5778`.
