### PR TITLE
Prevent Error utility instantiation

### DIFF
--- a/app/src/main/java/tools/vitruv/methodologist/messages/Error.java
+++ b/app/src/main/java/tools/vitruv/methodologist/messages/Error.java
@@ -2,6 +2,8 @@ package tools.vitruv.methodologist.messages;
 
 /** Contains error message constants used throughout the application. */
 public class Error {
+  private Error() {}
+
   public static final String CLIENT_NOT_FOUND_ERROR = "Client";
   public static final String USER_ID_NOT_FOUND_ERROR = "User id";
   public static final String VSUM_ID_NOT_FOUND_ERROR = "Vsum id";


### PR DESCRIPTION
## Summary

- Added a private constructor to the `Error` utility class.
- Prevents accidental instantiation of a constants-only class.
- Resolves Sonar rule `java:S1118`.
- Does not change runtime behavior.
